### PR TITLE
Fix pricing plans — Tiny 4k events, remove redundant features, mobile compare link

### DIFF
--- a/content/en/landings/brevo.mdx
+++ b/content/en/landings/brevo.mdx
@@ -474,7 +474,7 @@ PIMMS is one of our daily allies to stay on track and turn our profile into a le
         <PricingPlanFeatureListTitle>Everything in Free, plus:</PricingPlanFeatureListTitle>
         <PricingPlanFeatureList>
           <PricingPlanFeature>100 links /month</PricingPlanFeature>
-          <PricingPlanFeature>4,000 events tracked /month</PricingPlanFeature>
+          <PricingPlanFeature>1,500 events tracked /month</PricingPlanFeature>
           <PricingPlanFeature>1 custom domain</PricingPlanFeature>
           <PricingPlanFeature>Custom QR codes</PricingPlanFeature>
           <PricingPlanFeature>1 year of data</PricingPlanFeature>

--- a/content/en/landings/brevo.mdx
+++ b/content/en/landings/brevo.mdx
@@ -474,7 +474,7 @@ PIMMS is one of our daily allies to stay on track and turn our profile into a le
         <PricingPlanFeatureListTitle>Everything in Free, plus:</PricingPlanFeatureListTitle>
         <PricingPlanFeatureList>
           <PricingPlanFeature>100 links /month</PricingPlanFeature>
-          <PricingPlanFeature>Up to 1,500 clicks /month</PricingPlanFeature>
+          <PricingPlanFeature>4,000 events tracked /month</PricingPlanFeature>
           <PricingPlanFeature>1 custom domain</PricingPlanFeature>
           <PricingPlanFeature>Custom QR codes</PricingPlanFeature>
           <PricingPlanFeature>1 year of data</PricingPlanFeature>
@@ -487,8 +487,6 @@ PIMMS is one of our daily allies to stay on track and turn our profile into a le
         <PricingPlanFeatureListTitle>Everything in Tiny, plus:</PricingPlanFeatureListTitle>
         <PricingPlanFeatureList>
           <PricingPlanFeature>500 links /month</PricingPlanFeature>
-          <PricingPlanFeature>Unlimited sales tracking</PricingPlanFeature>
-          <PricingPlanFeature>Stripe payments integration</PricingPlanFeature>
           <PricingPlanFeature>A/B testing</PricingPlanFeature>
           <PricingPlanFeature>Webhooks &amp; API</PricingPlanFeature>
           <PricingPlanFeature>5 team members</PricingPlanFeature>
@@ -503,7 +501,6 @@ PIMMS is one of our daily allies to stay on track and turn our profile into a le
         <PricingPlanFeatureList>
           <PricingPlanFeature>1,000 links /month</PricingPlanFeature>
           <PricingPlanFeature>10k events tracked /month</PricingPlanFeature>
-          <PricingPlanFeature>Unlimited sales tracking</PricingPlanFeature>
           <PricingPlanFeature>5 custom domains</PricingPlanFeature>
           <PricingPlanFeature>Bulk link operations</PricingPlanFeature>
           <PricingPlanFeature>12 months of data</PricingPlanFeature>
@@ -517,7 +514,6 @@ PIMMS is one of our daily allies to stay on track and turn our profile into a le
         <PricingPlanFeatureList>
           <PricingPlanFeature>2,000 links /month</PricingPlanFeature>
           <PricingPlanFeature>20k events tracked /month</PricingPlanFeature>
-          <PricingPlanFeature>Unlimited sales tracking</PricingPlanFeature>
           <PricingPlanFeature>10 team members</PricingPlanFeature>
           <PricingPlanFeature>10 custom domains</PricingPlanFeature>
           <PricingPlanFeature>Bulk link operations</PricingPlanFeature>
@@ -526,6 +522,8 @@ PIMMS is one of our daily allies to stay on track and turn our profile into a le
         </PricingPlanFeatureList>
       </PricingPlanPanel>
     </PricingHero>
+
+    <Text size="sm" className="text-center mt-4"><a href="/pricing#compare" className="underline text-muted-foreground hover:text-foreground">Compare plans</a></Text>
   </Section>
 </Slide>
 

--- a/content/en/landings/calcom.mdx
+++ b/content/en/landings/calcom.mdx
@@ -345,7 +345,7 @@ With PIMMS, you have a clear vision. Simple. Without complexity. And in digital,
         <PricingPlanFeatureListTitle>Everything in Free, plus:</PricingPlanFeatureListTitle>
         <PricingPlanFeatureList>
           <PricingPlanFeature>100 links /month</PricingPlanFeature>
-          <PricingPlanFeature>4,000 events tracked /month</PricingPlanFeature>
+          <PricingPlanFeature>1,500 events tracked /month</PricingPlanFeature>
           <PricingPlanFeature>1 custom domain</PricingPlanFeature>
           <PricingPlanFeature>Custom QR codes</PricingPlanFeature>
           <PricingPlanFeature>1 year of data</PricingPlanFeature>

--- a/content/en/landings/calcom.mdx
+++ b/content/en/landings/calcom.mdx
@@ -345,7 +345,7 @@ With PIMMS, you have a clear vision. Simple. Without complexity. And in digital,
         <PricingPlanFeatureListTitle>Everything in Free, plus:</PricingPlanFeatureListTitle>
         <PricingPlanFeatureList>
           <PricingPlanFeature>100 links /month</PricingPlanFeature>
-          <PricingPlanFeature>Up to 1,500 clicks /month</PricingPlanFeature>
+          <PricingPlanFeature>4,000 events tracked /month</PricingPlanFeature>
           <PricingPlanFeature>1 custom domain</PricingPlanFeature>
           <PricingPlanFeature>Custom QR codes</PricingPlanFeature>
           <PricingPlanFeature>1 year of data</PricingPlanFeature>
@@ -358,8 +358,6 @@ With PIMMS, you have a clear vision. Simple. Without complexity. And in digital,
         <PricingPlanFeatureListTitle>Everything in Tiny, plus:</PricingPlanFeatureListTitle>
         <PricingPlanFeatureList>
           <PricingPlanFeature>500 links /month</PricingPlanFeature>
-          <PricingPlanFeature>Unlimited sales tracking</PricingPlanFeature>
-          <PricingPlanFeature>Stripe payments integration</PricingPlanFeature>
           <PricingPlanFeature>A/B testing</PricingPlanFeature>
           <PricingPlanFeature>Webhooks &amp; API</PricingPlanFeature>
           <PricingPlanFeature>5 team members</PricingPlanFeature>
@@ -374,7 +372,6 @@ With PIMMS, you have a clear vision. Simple. Without complexity. And in digital,
         <PricingPlanFeatureList>
           <PricingPlanFeature>1,000 links /month</PricingPlanFeature>
           <PricingPlanFeature>10k events tracked /month</PricingPlanFeature>
-          <PricingPlanFeature>Unlimited sales tracking</PricingPlanFeature>
           <PricingPlanFeature>5 custom domains</PricingPlanFeature>
           <PricingPlanFeature>Bulk link operations</PricingPlanFeature>
           <PricingPlanFeature>12 months of data</PricingPlanFeature>
@@ -388,7 +385,6 @@ With PIMMS, you have a clear vision. Simple. Without complexity. And in digital,
         <PricingPlanFeatureList>
           <PricingPlanFeature>2,000 links /month</PricingPlanFeature>
           <PricingPlanFeature>20k events tracked /month</PricingPlanFeature>
-          <PricingPlanFeature>Unlimited sales tracking</PricingPlanFeature>
           <PricingPlanFeature>10 team members</PricingPlanFeature>
           <PricingPlanFeature>10 custom domains</PricingPlanFeature>
           <PricingPlanFeature>Bulk link operations</PricingPlanFeature>
@@ -397,6 +393,8 @@ With PIMMS, you have a clear vision. Simple. Without complexity. And in digital,
         </PricingPlanFeatureList>
       </PricingPlanPanel>
     </PricingHero>
+
+    <Text size="sm" className="text-center mt-4"><a href="/pricing#compare" className="underline text-muted-foreground hover:text-foreground">Compare plans</a></Text>
   </Section>
 </Slide>
 

--- a/content/en/landings/calendly.mdx
+++ b/content/en/landings/calendly.mdx
@@ -475,7 +475,7 @@ PIMMS is one of our daily allies to stay on track and turn our profile into a le
         <PricingPlanFeatureListTitle>Everything in Free, plus:</PricingPlanFeatureListTitle>
         <PricingPlanFeatureList>
           <PricingPlanFeature>100 links /month</PricingPlanFeature>
-          <PricingPlanFeature>Up to 1,500 clicks /month</PricingPlanFeature>
+          <PricingPlanFeature>4,000 events tracked /month</PricingPlanFeature>
           <PricingPlanFeature>1 custom domain</PricingPlanFeature>
           <PricingPlanFeature>Custom QR codes</PricingPlanFeature>
           <PricingPlanFeature>1 year of data</PricingPlanFeature>
@@ -488,8 +488,6 @@ PIMMS is one of our daily allies to stay on track and turn our profile into a le
         <PricingPlanFeatureListTitle>Everything in Tiny, plus:</PricingPlanFeatureListTitle>
         <PricingPlanFeatureList>
           <PricingPlanFeature>500 links /month</PricingPlanFeature>
-          <PricingPlanFeature>Unlimited sales tracking</PricingPlanFeature>
-          <PricingPlanFeature>Stripe payments integration</PricingPlanFeature>
           <PricingPlanFeature>A/B testing</PricingPlanFeature>
           <PricingPlanFeature>Webhooks &amp; API</PricingPlanFeature>
           <PricingPlanFeature>5 team members</PricingPlanFeature>
@@ -504,7 +502,6 @@ PIMMS is one of our daily allies to stay on track and turn our profile into a le
         <PricingPlanFeatureList>
           <PricingPlanFeature>1,000 links /month</PricingPlanFeature>
           <PricingPlanFeature>10k events tracked /month</PricingPlanFeature>
-          <PricingPlanFeature>Unlimited sales tracking</PricingPlanFeature>
           <PricingPlanFeature>5 custom domains</PricingPlanFeature>
           <PricingPlanFeature>Bulk link operations</PricingPlanFeature>
           <PricingPlanFeature>12 months of data</PricingPlanFeature>
@@ -518,7 +515,6 @@ PIMMS is one of our daily allies to stay on track and turn our profile into a le
         <PricingPlanFeatureList>
           <PricingPlanFeature>2,000 links /month</PricingPlanFeature>
           <PricingPlanFeature>20k events tracked /month</PricingPlanFeature>
-          <PricingPlanFeature>Unlimited sales tracking</PricingPlanFeature>
           <PricingPlanFeature>10 team members</PricingPlanFeature>
           <PricingPlanFeature>10 custom domains</PricingPlanFeature>
           <PricingPlanFeature>Bulk link operations</PricingPlanFeature>
@@ -527,6 +523,8 @@ PIMMS is one of our daily allies to stay on track and turn our profile into a le
         </PricingPlanFeatureList>
       </PricingPlanPanel>
     </PricingHero>
+
+    <Text size="sm" className="text-center mt-4"><a href="/pricing#compare" className="underline text-muted-foreground hover:text-foreground">Compare plans</a></Text>
   </Section>
 </Slide>
 

--- a/content/en/landings/calendly.mdx
+++ b/content/en/landings/calendly.mdx
@@ -475,7 +475,7 @@ PIMMS is one of our daily allies to stay on track and turn our profile into a le
         <PricingPlanFeatureListTitle>Everything in Free, plus:</PricingPlanFeatureListTitle>
         <PricingPlanFeatureList>
           <PricingPlanFeature>100 links /month</PricingPlanFeature>
-          <PricingPlanFeature>4,000 events tracked /month</PricingPlanFeature>
+          <PricingPlanFeature>1,500 events tracked /month</PricingPlanFeature>
           <PricingPlanFeature>1 custom domain</PricingPlanFeature>
           <PricingPlanFeature>Custom QR codes</PricingPlanFeature>
           <PricingPlanFeature>1 year of data</PricingPlanFeature>

--- a/content/en/landings/elementor.mdx
+++ b/content/en/landings/elementor.mdx
@@ -345,7 +345,7 @@ With PIMMS, you have a clear vision. Simple. Without complexity. And in digital,
         <PricingPlanFeatureListTitle>Everything in Free, plus:</PricingPlanFeatureListTitle>
         <PricingPlanFeatureList>
           <PricingPlanFeature>100 links /month</PricingPlanFeature>
-          <PricingPlanFeature>4,000 events tracked /month</PricingPlanFeature>
+          <PricingPlanFeature>1,500 events tracked /month</PricingPlanFeature>
           <PricingPlanFeature>1 custom domain</PricingPlanFeature>
           <PricingPlanFeature>Custom QR codes</PricingPlanFeature>
           <PricingPlanFeature>1 year of data</PricingPlanFeature>

--- a/content/en/landings/elementor.mdx
+++ b/content/en/landings/elementor.mdx
@@ -345,7 +345,7 @@ With PIMMS, you have a clear vision. Simple. Without complexity. And in digital,
         <PricingPlanFeatureListTitle>Everything in Free, plus:</PricingPlanFeatureListTitle>
         <PricingPlanFeatureList>
           <PricingPlanFeature>100 links /month</PricingPlanFeature>
-          <PricingPlanFeature>Up to 1,500 clicks /month</PricingPlanFeature>
+          <PricingPlanFeature>4,000 events tracked /month</PricingPlanFeature>
           <PricingPlanFeature>1 custom domain</PricingPlanFeature>
           <PricingPlanFeature>Custom QR codes</PricingPlanFeature>
           <PricingPlanFeature>1 year of data</PricingPlanFeature>
@@ -358,8 +358,6 @@ With PIMMS, you have a clear vision. Simple. Without complexity. And in digital,
         <PricingPlanFeatureListTitle>Everything in Tiny, plus:</PricingPlanFeatureListTitle>
         <PricingPlanFeatureList>
           <PricingPlanFeature>500 links /month</PricingPlanFeature>
-          <PricingPlanFeature>Unlimited sales tracking</PricingPlanFeature>
-          <PricingPlanFeature>Stripe payments integration</PricingPlanFeature>
           <PricingPlanFeature>A/B testing</PricingPlanFeature>
           <PricingPlanFeature>Webhooks &amp; API</PricingPlanFeature>
           <PricingPlanFeature>5 team members</PricingPlanFeature>
@@ -374,7 +372,6 @@ With PIMMS, you have a clear vision. Simple. Without complexity. And in digital,
         <PricingPlanFeatureList>
           <PricingPlanFeature>1,000 links /month</PricingPlanFeature>
           <PricingPlanFeature>10k events tracked /month</PricingPlanFeature>
-          <PricingPlanFeature>Unlimited sales tracking</PricingPlanFeature>
           <PricingPlanFeature>5 custom domains</PricingPlanFeature>
           <PricingPlanFeature>Bulk link operations</PricingPlanFeature>
           <PricingPlanFeature>12 months of data</PricingPlanFeature>
@@ -388,7 +385,6 @@ With PIMMS, you have a clear vision. Simple. Without complexity. And in digital,
         <PricingPlanFeatureList>
           <PricingPlanFeature>2,000 links /month</PricingPlanFeature>
           <PricingPlanFeature>20k events tracked /month</PricingPlanFeature>
-          <PricingPlanFeature>Unlimited sales tracking</PricingPlanFeature>
           <PricingPlanFeature>10 team members</PricingPlanFeature>
           <PricingPlanFeature>10 custom domains</PricingPlanFeature>
           <PricingPlanFeature>Bulk link operations</PricingPlanFeature>
@@ -397,6 +393,8 @@ With PIMMS, you have a clear vision. Simple. Without complexity. And in digital,
         </PricingPlanFeatureList>
       </PricingPlanPanel>
     </PricingHero>
+
+    <Text size="sm" className="text-center mt-4"><a href="/pricing#compare" className="underline text-muted-foreground hover:text-foreground">Compare plans</a></Text>
   </Section>
 </Slide>
 

--- a/content/en/landings/framer.mdx
+++ b/content/en/landings/framer.mdx
@@ -475,7 +475,7 @@ PIMMS is one of our daily allies to stay on track and turn our profile into a le
         <PricingPlanFeatureListTitle>Everything in Free, plus:</PricingPlanFeatureListTitle>
         <PricingPlanFeatureList>
           <PricingPlanFeature>100 links /month</PricingPlanFeature>
-          <PricingPlanFeature>Up to 1,500 clicks /month</PricingPlanFeature>
+          <PricingPlanFeature>4,000 events tracked /month</PricingPlanFeature>
           <PricingPlanFeature>1 custom domain</PricingPlanFeature>
           <PricingPlanFeature>Custom QR codes</PricingPlanFeature>
           <PricingPlanFeature>1 year of data</PricingPlanFeature>
@@ -488,8 +488,6 @@ PIMMS is one of our daily allies to stay on track and turn our profile into a le
         <PricingPlanFeatureListTitle>Everything in Tiny, plus:</PricingPlanFeatureListTitle>
         <PricingPlanFeatureList>
           <PricingPlanFeature>500 links /month</PricingPlanFeature>
-          <PricingPlanFeature>Unlimited sales tracking</PricingPlanFeature>
-          <PricingPlanFeature>Stripe payments integration</PricingPlanFeature>
           <PricingPlanFeature>A/B testing</PricingPlanFeature>
           <PricingPlanFeature>Webhooks &amp; API</PricingPlanFeature>
           <PricingPlanFeature>5 team members</PricingPlanFeature>
@@ -504,7 +502,6 @@ PIMMS is one of our daily allies to stay on track and turn our profile into a le
         <PricingPlanFeatureList>
           <PricingPlanFeature>1,000 links /month</PricingPlanFeature>
           <PricingPlanFeature>10k events tracked /month</PricingPlanFeature>
-          <PricingPlanFeature>Unlimited sales tracking</PricingPlanFeature>
           <PricingPlanFeature>5 custom domains</PricingPlanFeature>
           <PricingPlanFeature>Bulk link operations</PricingPlanFeature>
           <PricingPlanFeature>12 months of data</PricingPlanFeature>
@@ -518,7 +515,6 @@ PIMMS is one of our daily allies to stay on track and turn our profile into a le
         <PricingPlanFeatureList>
           <PricingPlanFeature>2,000 links /month</PricingPlanFeature>
           <PricingPlanFeature>20k events tracked /month</PricingPlanFeature>
-          <PricingPlanFeature>Unlimited sales tracking</PricingPlanFeature>
           <PricingPlanFeature>10 team members</PricingPlanFeature>
           <PricingPlanFeature>10 custom domains</PricingPlanFeature>
           <PricingPlanFeature>Bulk link operations</PricingPlanFeature>
@@ -527,6 +523,8 @@ PIMMS is one of our daily allies to stay on track and turn our profile into a le
         </PricingPlanFeatureList>
       </PricingPlanPanel>
     </PricingHero>
+
+    <Text size="sm" className="text-center mt-4"><a href="/pricing#compare" className="underline text-muted-foreground hover:text-foreground">Compare plans</a></Text>
   </Section>
 </Slide>
 

--- a/content/en/landings/framer.mdx
+++ b/content/en/landings/framer.mdx
@@ -475,7 +475,7 @@ PIMMS is one of our daily allies to stay on track and turn our profile into a le
         <PricingPlanFeatureListTitle>Everything in Free, plus:</PricingPlanFeatureListTitle>
         <PricingPlanFeatureList>
           <PricingPlanFeature>100 links /month</PricingPlanFeature>
-          <PricingPlanFeature>4,000 events tracked /month</PricingPlanFeature>
+          <PricingPlanFeature>1,500 events tracked /month</PricingPlanFeature>
           <PricingPlanFeature>1 custom domain</PricingPlanFeature>
           <PricingPlanFeature>Custom QR codes</PricingPlanFeature>
           <PricingPlanFeature>1 year of data</PricingPlanFeature>

--- a/content/en/landings/home.mdx
+++ b/content/en/landings/home.mdx
@@ -418,7 +418,7 @@ PIMMS is one of our daily allies to stay on track and turn our profile into a le
         <PricingPlanFeatureListTitle>Everything in Free, plus:</PricingPlanFeatureListTitle>
         <PricingPlanFeatureList>
           <PricingPlanFeature>100 links /month</PricingPlanFeature>
-          <PricingPlanFeature>4,000 events tracked /month</PricingPlanFeature>
+          <PricingPlanFeature>1,500 events tracked /month</PricingPlanFeature>
           <PricingPlanFeature>1 custom domain</PricingPlanFeature>
           <PricingPlanFeature>Custom QR codes</PricingPlanFeature>
           <PricingPlanFeature>1 year of data</PricingPlanFeature>

--- a/content/en/landings/home.mdx
+++ b/content/en/landings/home.mdx
@@ -418,7 +418,7 @@ PIMMS is one of our daily allies to stay on track and turn our profile into a le
         <PricingPlanFeatureListTitle>Everything in Free, plus:</PricingPlanFeatureListTitle>
         <PricingPlanFeatureList>
           <PricingPlanFeature>100 links /month</PricingPlanFeature>
-          <PricingPlanFeature>Up to 1,500 clicks /month</PricingPlanFeature>
+          <PricingPlanFeature>4,000 events tracked /month</PricingPlanFeature>
           <PricingPlanFeature>1 custom domain</PricingPlanFeature>
           <PricingPlanFeature>Custom QR codes</PricingPlanFeature>
           <PricingPlanFeature>1 year of data</PricingPlanFeature>
@@ -431,8 +431,6 @@ PIMMS is one of our daily allies to stay on track and turn our profile into a le
         <PricingPlanFeatureListTitle>Everything in Tiny, plus:</PricingPlanFeatureListTitle>
         <PricingPlanFeatureList>
           <PricingPlanFeature>500 links /month</PricingPlanFeature>
-          <PricingPlanFeature>Unlimited sales tracking</PricingPlanFeature>
-          <PricingPlanFeature>Stripe payments integration</PricingPlanFeature>
           <PricingPlanFeature>A/B testing</PricingPlanFeature>
           <PricingPlanFeature>Webhooks &amp; API</PricingPlanFeature>
           <PricingPlanFeature>5 team members</PricingPlanFeature>
@@ -447,7 +445,6 @@ PIMMS is one of our daily allies to stay on track and turn our profile into a le
         <PricingPlanFeatureList>
           <PricingPlanFeature>1,000 links /month</PricingPlanFeature>
           <PricingPlanFeature>10k events tracked /month</PricingPlanFeature>
-          <PricingPlanFeature>Unlimited sales tracking</PricingPlanFeature>
           <PricingPlanFeature>5 custom domains</PricingPlanFeature>
           <PricingPlanFeature>Bulk link operations</PricingPlanFeature>
           <PricingPlanFeature>12 months of data</PricingPlanFeature>
@@ -461,7 +458,6 @@ PIMMS is one of our daily allies to stay on track and turn our profile into a le
         <PricingPlanFeatureList>
           <PricingPlanFeature>2,000 links /month</PricingPlanFeature>
           <PricingPlanFeature>20k events tracked /month</PricingPlanFeature>
-          <PricingPlanFeature>Unlimited sales tracking</PricingPlanFeature>
           <PricingPlanFeature>10 team members</PricingPlanFeature>
           <PricingPlanFeature>10 custom domains</PricingPlanFeature>
           <PricingPlanFeature>Bulk link operations</PricingPlanFeature>
@@ -470,6 +466,8 @@ PIMMS is one of our daily allies to stay on track and turn our profile into a le
         </PricingPlanFeatureList>
       </PricingPlanPanel>
     </PricingHero>
+
+    <Text size="sm" className="text-center mt-4"><a href="/pricing#compare" className="underline text-muted-foreground hover:text-foreground">Compare plans</a></Text>
   </Section>
 </Slide>
 

--- a/content/en/landings/iclosed.mdx
+++ b/content/en/landings/iclosed.mdx
@@ -475,7 +475,7 @@ PIMMS is one of our daily allies to stay on track and turn our profile into a le
         <PricingPlanFeatureListTitle>Everything in Free, plus:</PricingPlanFeatureListTitle>
         <PricingPlanFeatureList>
           <PricingPlanFeature>100 links /month</PricingPlanFeature>
-          <PricingPlanFeature>Up to 1,500 clicks /month</PricingPlanFeature>
+          <PricingPlanFeature>4,000 events tracked /month</PricingPlanFeature>
           <PricingPlanFeature>1 custom domain</PricingPlanFeature>
           <PricingPlanFeature>Custom QR codes</PricingPlanFeature>
           <PricingPlanFeature>1 year of data</PricingPlanFeature>
@@ -488,8 +488,6 @@ PIMMS is one of our daily allies to stay on track and turn our profile into a le
         <PricingPlanFeatureListTitle>Everything in Tiny, plus:</PricingPlanFeatureListTitle>
         <PricingPlanFeatureList>
           <PricingPlanFeature>500 links /month</PricingPlanFeature>
-          <PricingPlanFeature>Unlimited sales tracking</PricingPlanFeature>
-          <PricingPlanFeature>Stripe payments integration</PricingPlanFeature>
           <PricingPlanFeature>A/B testing</PricingPlanFeature>
           <PricingPlanFeature>Webhooks &amp; API</PricingPlanFeature>
           <PricingPlanFeature>5 team members</PricingPlanFeature>
@@ -504,7 +502,6 @@ PIMMS is one of our daily allies to stay on track and turn our profile into a le
         <PricingPlanFeatureList>
           <PricingPlanFeature>1,000 links /month</PricingPlanFeature>
           <PricingPlanFeature>10k events tracked /month</PricingPlanFeature>
-          <PricingPlanFeature>Unlimited sales tracking</PricingPlanFeature>
           <PricingPlanFeature>5 custom domains</PricingPlanFeature>
           <PricingPlanFeature>Bulk link operations</PricingPlanFeature>
           <PricingPlanFeature>12 months of data</PricingPlanFeature>
@@ -518,7 +515,6 @@ PIMMS is one of our daily allies to stay on track and turn our profile into a le
         <PricingPlanFeatureList>
           <PricingPlanFeature>2,000 links /month</PricingPlanFeature>
           <PricingPlanFeature>20k events tracked /month</PricingPlanFeature>
-          <PricingPlanFeature>Unlimited sales tracking</PricingPlanFeature>
           <PricingPlanFeature>10 team members</PricingPlanFeature>
           <PricingPlanFeature>10 custom domains</PricingPlanFeature>
           <PricingPlanFeature>Bulk link operations</PricingPlanFeature>
@@ -527,6 +523,8 @@ PIMMS is one of our daily allies to stay on track and turn our profile into a le
         </PricingPlanFeatureList>
       </PricingPlanPanel>
     </PricingHero>
+
+    <Text size="sm" className="text-center mt-4"><a href="/pricing#compare" className="underline text-muted-foreground hover:text-foreground">Compare plans</a></Text>
   </Section>
 </Slide>
 

--- a/content/en/landings/iclosed.mdx
+++ b/content/en/landings/iclosed.mdx
@@ -475,7 +475,7 @@ PIMMS is one of our daily allies to stay on track and turn our profile into a le
         <PricingPlanFeatureListTitle>Everything in Free, plus:</PricingPlanFeatureListTitle>
         <PricingPlanFeatureList>
           <PricingPlanFeature>100 links /month</PricingPlanFeature>
-          <PricingPlanFeature>4,000 events tracked /month</PricingPlanFeature>
+          <PricingPlanFeature>1,500 events tracked /month</PricingPlanFeature>
           <PricingPlanFeature>1 custom domain</PricingPlanFeature>
           <PricingPlanFeature>Custom QR codes</PricingPlanFeature>
           <PricingPlanFeature>1 year of data</PricingPlanFeature>

--- a/content/en/landings/landing-page-tracking.mdx
+++ b/content/en/landings/landing-page-tracking.mdx
@@ -299,7 +299,7 @@ To know where each click comes from and optimize what really works!
         <PricingPlanFeatureListTitle>Everything in Free, plus:</PricingPlanFeatureListTitle>
         <PricingPlanFeatureList>
           <PricingPlanFeature>100 links /month</PricingPlanFeature>
-          <PricingPlanFeature>4,000 events tracked /month</PricingPlanFeature>
+          <PricingPlanFeature>1,500 events tracked /month</PricingPlanFeature>
           <PricingPlanFeature>1 custom domain</PricingPlanFeature>
           <PricingPlanFeature>Custom QR codes</PricingPlanFeature>
           <PricingPlanFeature>1 year of data</PricingPlanFeature>

--- a/content/en/landings/landing-page-tracking.mdx
+++ b/content/en/landings/landing-page-tracking.mdx
@@ -299,7 +299,7 @@ To know where each click comes from and optimize what really works!
         <PricingPlanFeatureListTitle>Everything in Free, plus:</PricingPlanFeatureListTitle>
         <PricingPlanFeatureList>
           <PricingPlanFeature>100 links /month</PricingPlanFeature>
-          <PricingPlanFeature>Up to 1,500 clicks /month</PricingPlanFeature>
+          <PricingPlanFeature>4,000 events tracked /month</PricingPlanFeature>
           <PricingPlanFeature>1 custom domain</PricingPlanFeature>
           <PricingPlanFeature>Custom QR codes</PricingPlanFeature>
           <PricingPlanFeature>1 year of data</PricingPlanFeature>
@@ -312,8 +312,6 @@ To know where each click comes from and optimize what really works!
         <PricingPlanFeatureListTitle>Everything in Tiny, plus:</PricingPlanFeatureListTitle>
         <PricingPlanFeatureList>
           <PricingPlanFeature>500 links /month</PricingPlanFeature>
-          <PricingPlanFeature>Unlimited sales tracking</PricingPlanFeature>
-          <PricingPlanFeature>Stripe payments integration</PricingPlanFeature>
           <PricingPlanFeature>A/B testing</PricingPlanFeature>
           <PricingPlanFeature>Webhooks &amp; API</PricingPlanFeature>
           <PricingPlanFeature>5 team members</PricingPlanFeature>
@@ -328,7 +326,6 @@ To know where each click comes from and optimize what really works!
         <PricingPlanFeatureList>
           <PricingPlanFeature>1,000 links /month</PricingPlanFeature>
           <PricingPlanFeature>10k events tracked /month</PricingPlanFeature>
-          <PricingPlanFeature>Unlimited sales tracking</PricingPlanFeature>
           <PricingPlanFeature>5 custom domains</PricingPlanFeature>
           <PricingPlanFeature>Bulk link operations</PricingPlanFeature>
           <PricingPlanFeature>12 months of data</PricingPlanFeature>
@@ -342,7 +339,6 @@ To know where each click comes from and optimize what really works!
         <PricingPlanFeatureList>
           <PricingPlanFeature>2,000 links /month</PricingPlanFeature>
           <PricingPlanFeature>20k events tracked /month</PricingPlanFeature>
-          <PricingPlanFeature>Unlimited sales tracking</PricingPlanFeature>
           <PricingPlanFeature>10 team members</PricingPlanFeature>
           <PricingPlanFeature>10 custom domains</PricingPlanFeature>
           <PricingPlanFeature>Bulk link operations</PricingPlanFeature>
@@ -351,6 +347,8 @@ To know where each click comes from and optimize what really works!
         </PricingPlanFeatureList>
       </PricingPlanPanel>
     </PricingHero>
+
+    <Text size="sm" className="text-center mt-4"><a href="/pricing#compare" className="underline text-muted-foreground hover:text-foreground">Compare plans</a></Text>
   </Section>
 </Slide>
 

--- a/content/en/landings/linkedin-tracker.mdx
+++ b/content/en/landings/linkedin-tracker.mdx
@@ -301,7 +301,7 @@ And when I launch a new page, if the visitor is identified on one of my pages, t
         <PricingPlanFeatureListTitle>Everything in Free, plus:</PricingPlanFeatureListTitle>
         <PricingPlanFeatureList>
           <PricingPlanFeature>100 links /month</PricingPlanFeature>
-          <PricingPlanFeature>Up to 1,500 clicks /month</PricingPlanFeature>
+          <PricingPlanFeature>4,000 events tracked /month</PricingPlanFeature>
           <PricingPlanFeature>1 custom domain</PricingPlanFeature>
           <PricingPlanFeature>Custom QR codes</PricingPlanFeature>
           <PricingPlanFeature>1 year of data</PricingPlanFeature>
@@ -314,8 +314,6 @@ And when I launch a new page, if the visitor is identified on one of my pages, t
         <PricingPlanFeatureListTitle>Everything in Tiny, plus:</PricingPlanFeatureListTitle>
         <PricingPlanFeatureList>
           <PricingPlanFeature>500 links /month</PricingPlanFeature>
-          <PricingPlanFeature>Unlimited sales tracking</PricingPlanFeature>
-          <PricingPlanFeature>Stripe payments integration</PricingPlanFeature>
           <PricingPlanFeature>A/B testing</PricingPlanFeature>
           <PricingPlanFeature>Webhooks &amp; API</PricingPlanFeature>
           <PricingPlanFeature>5 team members</PricingPlanFeature>
@@ -330,7 +328,6 @@ And when I launch a new page, if the visitor is identified on one of my pages, t
         <PricingPlanFeatureList>
           <PricingPlanFeature>1,000 links /month</PricingPlanFeature>
           <PricingPlanFeature>10k events tracked /month</PricingPlanFeature>
-          <PricingPlanFeature>Unlimited sales tracking</PricingPlanFeature>
           <PricingPlanFeature>5 custom domains</PricingPlanFeature>
           <PricingPlanFeature>Bulk link operations</PricingPlanFeature>
           <PricingPlanFeature>12 months of data</PricingPlanFeature>
@@ -344,7 +341,6 @@ And when I launch a new page, if the visitor is identified on one of my pages, t
         <PricingPlanFeatureList>
           <PricingPlanFeature>2,000 links /month</PricingPlanFeature>
           <PricingPlanFeature>20k events tracked /month</PricingPlanFeature>
-          <PricingPlanFeature>Unlimited sales tracking</PricingPlanFeature>
           <PricingPlanFeature>10 team members</PricingPlanFeature>
           <PricingPlanFeature>10 custom domains</PricingPlanFeature>
           <PricingPlanFeature>Bulk link operations</PricingPlanFeature>
@@ -353,6 +349,8 @@ And when I launch a new page, if the visitor is identified on one of my pages, t
         </PricingPlanFeatureList>
       </PricingPlanPanel>
     </PricingHero>
+
+    <Text size="sm" className="text-center mt-4"><a href="/pricing#compare" className="underline text-muted-foreground hover:text-foreground">Compare plans</a></Text>
   </Section>
 </Slide>
 

--- a/content/en/landings/linkedin-tracker.mdx
+++ b/content/en/landings/linkedin-tracker.mdx
@@ -301,7 +301,7 @@ And when I launch a new page, if the visitor is identified on one of my pages, t
         <PricingPlanFeatureListTitle>Everything in Free, plus:</PricingPlanFeatureListTitle>
         <PricingPlanFeatureList>
           <PricingPlanFeature>100 links /month</PricingPlanFeature>
-          <PricingPlanFeature>4,000 events tracked /month</PricingPlanFeature>
+          <PricingPlanFeature>1,500 events tracked /month</PricingPlanFeature>
           <PricingPlanFeature>1 custom domain</PricingPlanFeature>
           <PricingPlanFeature>Custom QR codes</PricingPlanFeature>
           <PricingPlanFeature>1 year of data</PricingPlanFeature>

--- a/content/en/landings/podia.mdx
+++ b/content/en/landings/podia.mdx
@@ -345,7 +345,7 @@ With PIMMS, you have a clear vision. Simple. Without complexity. And in digital,
         <PricingPlanFeatureListTitle>Everything in Free, plus:</PricingPlanFeatureListTitle>
         <PricingPlanFeatureList>
           <PricingPlanFeature>100 links /month</PricingPlanFeature>
-          <PricingPlanFeature>4,000 events tracked /month</PricingPlanFeature>
+          <PricingPlanFeature>1,500 events tracked /month</PricingPlanFeature>
           <PricingPlanFeature>1 custom domain</PricingPlanFeature>
           <PricingPlanFeature>Custom QR codes</PricingPlanFeature>
           <PricingPlanFeature>1 year of data</PricingPlanFeature>

--- a/content/en/landings/podia.mdx
+++ b/content/en/landings/podia.mdx
@@ -345,7 +345,7 @@ With PIMMS, you have a clear vision. Simple. Without complexity. And in digital,
         <PricingPlanFeatureListTitle>Everything in Free, plus:</PricingPlanFeatureListTitle>
         <PricingPlanFeatureList>
           <PricingPlanFeature>100 links /month</PricingPlanFeature>
-          <PricingPlanFeature>Up to 1,500 clicks /month</PricingPlanFeature>
+          <PricingPlanFeature>4,000 events tracked /month</PricingPlanFeature>
           <PricingPlanFeature>1 custom domain</PricingPlanFeature>
           <PricingPlanFeature>Custom QR codes</PricingPlanFeature>
           <PricingPlanFeature>1 year of data</PricingPlanFeature>
@@ -358,8 +358,6 @@ With PIMMS, you have a clear vision. Simple. Without complexity. And in digital,
         <PricingPlanFeatureListTitle>Everything in Tiny, plus:</PricingPlanFeatureListTitle>
         <PricingPlanFeatureList>
           <PricingPlanFeature>500 links /month</PricingPlanFeature>
-          <PricingPlanFeature>Unlimited sales tracking</PricingPlanFeature>
-          <PricingPlanFeature>Stripe payments integration</PricingPlanFeature>
           <PricingPlanFeature>A/B testing</PricingPlanFeature>
           <PricingPlanFeature>Webhooks &amp; API</PricingPlanFeature>
           <PricingPlanFeature>5 team members</PricingPlanFeature>
@@ -374,7 +372,6 @@ With PIMMS, you have a clear vision. Simple. Without complexity. And in digital,
         <PricingPlanFeatureList>
           <PricingPlanFeature>1,000 links /month</PricingPlanFeature>
           <PricingPlanFeature>10k events tracked /month</PricingPlanFeature>
-          <PricingPlanFeature>Unlimited sales tracking</PricingPlanFeature>
           <PricingPlanFeature>5 custom domains</PricingPlanFeature>
           <PricingPlanFeature>Bulk link operations</PricingPlanFeature>
           <PricingPlanFeature>12 months of data</PricingPlanFeature>
@@ -388,7 +385,6 @@ With PIMMS, you have a clear vision. Simple. Without complexity. And in digital,
         <PricingPlanFeatureList>
           <PricingPlanFeature>2,000 links /month</PricingPlanFeature>
           <PricingPlanFeature>20k events tracked /month</PricingPlanFeature>
-          <PricingPlanFeature>Unlimited sales tracking</PricingPlanFeature>
           <PricingPlanFeature>10 team members</PricingPlanFeature>
           <PricingPlanFeature>10 custom domains</PricingPlanFeature>
           <PricingPlanFeature>Bulk link operations</PricingPlanFeature>
@@ -397,6 +393,8 @@ With PIMMS, you have a clear vision. Simple. Without complexity. And in digital,
         </PricingPlanFeatureList>
       </PricingPlanPanel>
     </PricingHero>
+
+    <Text size="sm" className="text-center mt-4"><a href="/pricing#compare" className="underline text-muted-foreground hover:text-foreground">Compare plans</a></Text>
   </Section>
 </Slide>
 

--- a/content/en/landings/pricing.mdx
+++ b/content/en/landings/pricing.mdx
@@ -44,7 +44,7 @@ folder: ""
         <PricingPlanFeatureListTitle>Everything in Free, plus:</PricingPlanFeatureListTitle>
         <PricingPlanFeatureList>
           <PricingPlanFeature>100 links /month</PricingPlanFeature>
-          <PricingPlanFeature>Up to 1,500 clicks /month</PricingPlanFeature>
+          <PricingPlanFeature>4,000 events tracked /month</PricingPlanFeature>
           <PricingPlanFeature>1 custom domain</PricingPlanFeature>
           <PricingPlanFeature>Custom QR codes</PricingPlanFeature>
           <PricingPlanFeature>1 year of data</PricingPlanFeature>
@@ -57,8 +57,6 @@ folder: ""
         <PricingPlanFeatureListTitle>Everything in Tiny, plus:</PricingPlanFeatureListTitle>
         <PricingPlanFeatureList>
           <PricingPlanFeature>500 links /month</PricingPlanFeature>
-          <PricingPlanFeature>Unlimited sales tracking</PricingPlanFeature>
-          <PricingPlanFeature>Stripe payments integration</PricingPlanFeature>
           <PricingPlanFeature>A/B testing</PricingPlanFeature>
           <PricingPlanFeature>Webhooks &amp; API</PricingPlanFeature>
           <PricingPlanFeature>5 team members</PricingPlanFeature>
@@ -73,7 +71,6 @@ folder: ""
         <PricingPlanFeatureList>
           <PricingPlanFeature>1,000 links /month</PricingPlanFeature>
           <PricingPlanFeature>10k events tracked /month</PricingPlanFeature>
-          <PricingPlanFeature>Unlimited sales tracking</PricingPlanFeature>
           <PricingPlanFeature>5 custom domains</PricingPlanFeature>
           <PricingPlanFeature>Bulk link operations</PricingPlanFeature>
           <PricingPlanFeature>12 months of data</PricingPlanFeature>
@@ -87,7 +84,6 @@ folder: ""
         <PricingPlanFeatureList>
           <PricingPlanFeature>2,000 links /month</PricingPlanFeature>
           <PricingPlanFeature>20k events tracked /month</PricingPlanFeature>
-          <PricingPlanFeature>Unlimited sales tracking</PricingPlanFeature>
           <PricingPlanFeature>10 team members</PricingPlanFeature>
           <PricingPlanFeature>10 custom domains</PricingPlanFeature>
           <PricingPlanFeature>Bulk link operations</PricingPlanFeature>
@@ -97,7 +93,9 @@ folder: ""
       </PricingPlanPanel>
     </PricingHero>
 
-    <H2>Compare plans in detail</H2>
+    <Text size="sm" className="text-center mt-4"><a href="#compare" className="underline text-muted-foreground hover:text-foreground">Compare plans</a></Text>
+
+    <H2 id="compare">Compare plans in detail</H2>
     <CompareTable featuresHeader="Features" freeLabel="Free" atATime="at a time" unlimited="Unlimited">
         <CompareCategory>Links</CompareCategory>
         <CompareFeatureValue limitKey="links">New links/month</CompareFeatureValue>

--- a/content/en/landings/pricing.mdx
+++ b/content/en/landings/pricing.mdx
@@ -44,7 +44,7 @@ folder: ""
         <PricingPlanFeatureListTitle>Everything in Free, plus:</PricingPlanFeatureListTitle>
         <PricingPlanFeatureList>
           <PricingPlanFeature>100 links /month</PricingPlanFeature>
-          <PricingPlanFeature>4,000 events tracked /month</PricingPlanFeature>
+          <PricingPlanFeature>1,500 events tracked /month</PricingPlanFeature>
           <PricingPlanFeature>1 custom domain</PricingPlanFeature>
           <PricingPlanFeature>Custom QR codes</PricingPlanFeature>
           <PricingPlanFeature>1 year of data</PricingPlanFeature>

--- a/content/en/landings/stripe.mdx
+++ b/content/en/landings/stripe.mdx
@@ -475,7 +475,7 @@ PIMMS is one of our daily allies to stay on track and turn our profile into a le
         <PricingPlanFeatureListTitle>Everything in Free, plus:</PricingPlanFeatureListTitle>
         <PricingPlanFeatureList>
           <PricingPlanFeature>100 links /month</PricingPlanFeature>
-          <PricingPlanFeature>Up to 1,500 clicks /month</PricingPlanFeature>
+          <PricingPlanFeature>4,000 events tracked /month</PricingPlanFeature>
           <PricingPlanFeature>1 custom domain</PricingPlanFeature>
           <PricingPlanFeature>Custom QR codes</PricingPlanFeature>
           <PricingPlanFeature>1 year of data</PricingPlanFeature>
@@ -488,8 +488,6 @@ PIMMS is one of our daily allies to stay on track and turn our profile into a le
         <PricingPlanFeatureListTitle>Everything in Tiny, plus:</PricingPlanFeatureListTitle>
         <PricingPlanFeatureList>
           <PricingPlanFeature>500 links /month</PricingPlanFeature>
-          <PricingPlanFeature>Unlimited sales tracking</PricingPlanFeature>
-          <PricingPlanFeature>Stripe payments integration</PricingPlanFeature>
           <PricingPlanFeature>A/B testing</PricingPlanFeature>
           <PricingPlanFeature>Webhooks &amp; API</PricingPlanFeature>
           <PricingPlanFeature>5 team members</PricingPlanFeature>
@@ -504,7 +502,6 @@ PIMMS is one of our daily allies to stay on track and turn our profile into a le
         <PricingPlanFeatureList>
           <PricingPlanFeature>1,000 links /month</PricingPlanFeature>
           <PricingPlanFeature>10k events tracked /month</PricingPlanFeature>
-          <PricingPlanFeature>Unlimited sales tracking</PricingPlanFeature>
           <PricingPlanFeature>5 custom domains</PricingPlanFeature>
           <PricingPlanFeature>Bulk link operations</PricingPlanFeature>
           <PricingPlanFeature>12 months of data</PricingPlanFeature>
@@ -518,7 +515,6 @@ PIMMS is one of our daily allies to stay on track and turn our profile into a le
         <PricingPlanFeatureList>
           <PricingPlanFeature>2,000 links /month</PricingPlanFeature>
           <PricingPlanFeature>20k events tracked /month</PricingPlanFeature>
-          <PricingPlanFeature>Unlimited sales tracking</PricingPlanFeature>
           <PricingPlanFeature>10 team members</PricingPlanFeature>
           <PricingPlanFeature>10 custom domains</PricingPlanFeature>
           <PricingPlanFeature>Bulk link operations</PricingPlanFeature>
@@ -527,6 +523,8 @@ PIMMS is one of our daily allies to stay on track and turn our profile into a le
         </PricingPlanFeatureList>
       </PricingPlanPanel>
     </PricingHero>
+
+    <Text size="sm" className="text-center mt-4"><a href="/pricing#compare" className="underline text-muted-foreground hover:text-foreground">Compare plans</a></Text>
   </Section>
 </Slide>
 

--- a/content/en/landings/stripe.mdx
+++ b/content/en/landings/stripe.mdx
@@ -475,7 +475,7 @@ PIMMS is one of our daily allies to stay on track and turn our profile into a le
         <PricingPlanFeatureListTitle>Everything in Free, plus:</PricingPlanFeatureListTitle>
         <PricingPlanFeatureList>
           <PricingPlanFeature>100 links /month</PricingPlanFeature>
-          <PricingPlanFeature>4,000 events tracked /month</PricingPlanFeature>
+          <PricingPlanFeature>1,500 events tracked /month</PricingPlanFeature>
           <PricingPlanFeature>1 custom domain</PricingPlanFeature>
           <PricingPlanFeature>Custom QR codes</PricingPlanFeature>
           <PricingPlanFeature>1 year of data</PricingPlanFeature>

--- a/content/en/landings/systemeio.mdx
+++ b/content/en/landings/systemeio.mdx
@@ -475,7 +475,7 @@ PIMMS is one of our daily allies to stay on track and turn our profile into a le
         <PricingPlanFeatureListTitle>Everything in Free, plus:</PricingPlanFeatureListTitle>
         <PricingPlanFeatureList>
           <PricingPlanFeature>100 links /month</PricingPlanFeature>
-          <PricingPlanFeature>Up to 1,500 clicks /month</PricingPlanFeature>
+          <PricingPlanFeature>4,000 events tracked /month</PricingPlanFeature>
           <PricingPlanFeature>1 custom domain</PricingPlanFeature>
           <PricingPlanFeature>Custom QR codes</PricingPlanFeature>
           <PricingPlanFeature>1 year of data</PricingPlanFeature>
@@ -488,8 +488,6 @@ PIMMS is one of our daily allies to stay on track and turn our profile into a le
         <PricingPlanFeatureListTitle>Everything in Tiny, plus:</PricingPlanFeatureListTitle>
         <PricingPlanFeatureList>
           <PricingPlanFeature>500 links /month</PricingPlanFeature>
-          <PricingPlanFeature>Unlimited sales tracking</PricingPlanFeature>
-          <PricingPlanFeature>Stripe payments integration</PricingPlanFeature>
           <PricingPlanFeature>A/B testing</PricingPlanFeature>
           <PricingPlanFeature>Webhooks &amp; API</PricingPlanFeature>
           <PricingPlanFeature>5 team members</PricingPlanFeature>
@@ -504,7 +502,6 @@ PIMMS is one of our daily allies to stay on track and turn our profile into a le
         <PricingPlanFeatureList>
           <PricingPlanFeature>1,000 links /month</PricingPlanFeature>
           <PricingPlanFeature>10k events tracked /month</PricingPlanFeature>
-          <PricingPlanFeature>Unlimited sales tracking</PricingPlanFeature>
           <PricingPlanFeature>5 custom domains</PricingPlanFeature>
           <PricingPlanFeature>Bulk link operations</PricingPlanFeature>
           <PricingPlanFeature>12 months of data</PricingPlanFeature>
@@ -518,7 +515,6 @@ PIMMS is one of our daily allies to stay on track and turn our profile into a le
         <PricingPlanFeatureList>
           <PricingPlanFeature>2,000 links /month</PricingPlanFeature>
           <PricingPlanFeature>20k events tracked /month</PricingPlanFeature>
-          <PricingPlanFeature>Unlimited sales tracking</PricingPlanFeature>
           <PricingPlanFeature>10 team members</PricingPlanFeature>
           <PricingPlanFeature>10 custom domains</PricingPlanFeature>
           <PricingPlanFeature>Bulk link operations</PricingPlanFeature>
@@ -527,6 +523,8 @@ PIMMS is one of our daily allies to stay on track and turn our profile into a le
         </PricingPlanFeatureList>
       </PricingPlanPanel>
     </PricingHero>
+
+    <Text size="sm" className="text-center mt-4"><a href="/pricing#compare" className="underline text-muted-foreground hover:text-foreground">Compare plans</a></Text>
   </Section>
 </Slide>
 

--- a/content/en/landings/systemeio.mdx
+++ b/content/en/landings/systemeio.mdx
@@ -475,7 +475,7 @@ PIMMS is one of our daily allies to stay on track and turn our profile into a le
         <PricingPlanFeatureListTitle>Everything in Free, plus:</PricingPlanFeatureListTitle>
         <PricingPlanFeatureList>
           <PricingPlanFeature>100 links /month</PricingPlanFeature>
-          <PricingPlanFeature>4,000 events tracked /month</PricingPlanFeature>
+          <PricingPlanFeature>1,500 events tracked /month</PricingPlanFeature>
           <PricingPlanFeature>1 custom domain</PricingPlanFeature>
           <PricingPlanFeature>Custom QR codes</PricingPlanFeature>
           <PricingPlanFeature>1 year of data</PricingPlanFeature>

--- a/content/en/landings/tally.mdx
+++ b/content/en/landings/tally.mdx
@@ -475,7 +475,7 @@ PIMMS is one of our daily allies to stay on track and turn our profile into a le
         <PricingPlanFeatureListTitle>Everything in Free, plus:</PricingPlanFeatureListTitle>
         <PricingPlanFeatureList>
           <PricingPlanFeature>100 links /month</PricingPlanFeature>
-          <PricingPlanFeature>Up to 1,500 clicks /month</PricingPlanFeature>
+          <PricingPlanFeature>4,000 events tracked /month</PricingPlanFeature>
           <PricingPlanFeature>1 custom domain</PricingPlanFeature>
           <PricingPlanFeature>Custom QR codes</PricingPlanFeature>
           <PricingPlanFeature>1 year of data</PricingPlanFeature>
@@ -488,8 +488,6 @@ PIMMS is one of our daily allies to stay on track and turn our profile into a le
         <PricingPlanFeatureListTitle>Everything in Tiny, plus:</PricingPlanFeatureListTitle>
         <PricingPlanFeatureList>
           <PricingPlanFeature>500 links /month</PricingPlanFeature>
-          <PricingPlanFeature>Unlimited sales tracking</PricingPlanFeature>
-          <PricingPlanFeature>Stripe payments integration</PricingPlanFeature>
           <PricingPlanFeature>A/B testing</PricingPlanFeature>
           <PricingPlanFeature>Webhooks &amp; API</PricingPlanFeature>
           <PricingPlanFeature>5 team members</PricingPlanFeature>
@@ -504,7 +502,6 @@ PIMMS is one of our daily allies to stay on track and turn our profile into a le
         <PricingPlanFeatureList>
           <PricingPlanFeature>1,000 links /month</PricingPlanFeature>
           <PricingPlanFeature>10k events tracked /month</PricingPlanFeature>
-          <PricingPlanFeature>Unlimited sales tracking</PricingPlanFeature>
           <PricingPlanFeature>5 custom domains</PricingPlanFeature>
           <PricingPlanFeature>Bulk link operations</PricingPlanFeature>
           <PricingPlanFeature>12 months of data</PricingPlanFeature>
@@ -518,7 +515,6 @@ PIMMS is one of our daily allies to stay on track and turn our profile into a le
         <PricingPlanFeatureList>
           <PricingPlanFeature>2,000 links /month</PricingPlanFeature>
           <PricingPlanFeature>20k events tracked /month</PricingPlanFeature>
-          <PricingPlanFeature>Unlimited sales tracking</PricingPlanFeature>
           <PricingPlanFeature>10 team members</PricingPlanFeature>
           <PricingPlanFeature>10 custom domains</PricingPlanFeature>
           <PricingPlanFeature>Bulk link operations</PricingPlanFeature>
@@ -527,6 +523,8 @@ PIMMS is one of our daily allies to stay on track and turn our profile into a le
         </PricingPlanFeatureList>
       </PricingPlanPanel>
     </PricingHero>
+
+    <Text size="sm" className="text-center mt-4"><a href="/pricing#compare" className="underline text-muted-foreground hover:text-foreground">Compare plans</a></Text>
   </Section>
 </Slide>
 

--- a/content/en/landings/tally.mdx
+++ b/content/en/landings/tally.mdx
@@ -475,7 +475,7 @@ PIMMS is one of our daily allies to stay on track and turn our profile into a le
         <PricingPlanFeatureListTitle>Everything in Free, plus:</PricingPlanFeatureListTitle>
         <PricingPlanFeatureList>
           <PricingPlanFeature>100 links /month</PricingPlanFeature>
-          <PricingPlanFeature>4,000 events tracked /month</PricingPlanFeature>
+          <PricingPlanFeature>1,500 events tracked /month</PricingPlanFeature>
           <PricingPlanFeature>1 custom domain</PricingPlanFeature>
           <PricingPlanFeature>Custom QR codes</PricingPlanFeature>
           <PricingPlanFeature>1 year of data</PricingPlanFeature>

--- a/content/en/landings/utm.mdx
+++ b/content/en/landings/utm.mdx
@@ -486,7 +486,7 @@ utm_content=issue-47
         <PricingPlanFeatureListTitle>Everything in Free, plus:</PricingPlanFeatureListTitle>
         <PricingPlanFeatureList>
           <PricingPlanFeature>100 links /month</PricingPlanFeature>
-          <PricingPlanFeature>4,000 events tracked /month</PricingPlanFeature>
+          <PricingPlanFeature>1,500 events tracked /month</PricingPlanFeature>
           <PricingPlanFeature>1 custom domain</PricingPlanFeature>
           <PricingPlanFeature>Custom QR codes</PricingPlanFeature>
           <PricingPlanFeature>1 year of data</PricingPlanFeature>

--- a/content/en/landings/utm.mdx
+++ b/content/en/landings/utm.mdx
@@ -486,7 +486,7 @@ utm_content=issue-47
         <PricingPlanFeatureListTitle>Everything in Free, plus:</PricingPlanFeatureListTitle>
         <PricingPlanFeatureList>
           <PricingPlanFeature>100 links /month</PricingPlanFeature>
-          <PricingPlanFeature>Up to 1,500 clicks /month</PricingPlanFeature>
+          <PricingPlanFeature>4,000 events tracked /month</PricingPlanFeature>
           <PricingPlanFeature>1 custom domain</PricingPlanFeature>
           <PricingPlanFeature>Custom QR codes</PricingPlanFeature>
           <PricingPlanFeature>1 year of data</PricingPlanFeature>
@@ -499,8 +499,6 @@ utm_content=issue-47
         <PricingPlanFeatureListTitle>Everything in Tiny, plus:</PricingPlanFeatureListTitle>
         <PricingPlanFeatureList>
           <PricingPlanFeature>500 links /month</PricingPlanFeature>
-          <PricingPlanFeature>Unlimited sales tracking</PricingPlanFeature>
-          <PricingPlanFeature>Stripe payments integration</PricingPlanFeature>
           <PricingPlanFeature>A/B testing</PricingPlanFeature>
           <PricingPlanFeature>Webhooks &amp; API</PricingPlanFeature>
           <PricingPlanFeature>5 team members</PricingPlanFeature>
@@ -515,7 +513,6 @@ utm_content=issue-47
         <PricingPlanFeatureList>
           <PricingPlanFeature>1,000 links /month</PricingPlanFeature>
           <PricingPlanFeature>10k events tracked /month</PricingPlanFeature>
-          <PricingPlanFeature>Unlimited sales tracking</PricingPlanFeature>
           <PricingPlanFeature>5 custom domains</PricingPlanFeature>
           <PricingPlanFeature>Bulk link operations</PricingPlanFeature>
           <PricingPlanFeature>12 months of data</PricingPlanFeature>
@@ -529,7 +526,6 @@ utm_content=issue-47
         <PricingPlanFeatureList>
           <PricingPlanFeature>2,000 links /month</PricingPlanFeature>
           <PricingPlanFeature>20k events tracked /month</PricingPlanFeature>
-          <PricingPlanFeature>Unlimited sales tracking</PricingPlanFeature>
           <PricingPlanFeature>10 team members</PricingPlanFeature>
           <PricingPlanFeature>10 custom domains</PricingPlanFeature>
           <PricingPlanFeature>Bulk link operations</PricingPlanFeature>
@@ -538,6 +534,8 @@ utm_content=issue-47
         </PricingPlanFeatureList>
       </PricingPlanPanel>
     </PricingHero>
+
+    <Text size="sm" className="text-center mt-4"><a href="/pricing#compare" className="underline text-muted-foreground hover:text-foreground">Compare plans</a></Text>
   </Section>
 </Slide>
 

--- a/content/en/landings/webflow.mdx
+++ b/content/en/landings/webflow.mdx
@@ -475,7 +475,7 @@ PIMMS is one of our daily allies to stay on track and turn our profile into a le
         <PricingPlanFeatureListTitle>Everything in Free, plus:</PricingPlanFeatureListTitle>
         <PricingPlanFeatureList>
           <PricingPlanFeature>100 links /month</PricingPlanFeature>
-          <PricingPlanFeature>Up to 1,500 clicks /month</PricingPlanFeature>
+          <PricingPlanFeature>4,000 events tracked /month</PricingPlanFeature>
           <PricingPlanFeature>1 custom domain</PricingPlanFeature>
           <PricingPlanFeature>Custom QR codes</PricingPlanFeature>
           <PricingPlanFeature>1 year of data</PricingPlanFeature>
@@ -488,8 +488,6 @@ PIMMS is one of our daily allies to stay on track and turn our profile into a le
         <PricingPlanFeatureListTitle>Everything in Tiny, plus:</PricingPlanFeatureListTitle>
         <PricingPlanFeatureList>
           <PricingPlanFeature>500 links /month</PricingPlanFeature>
-          <PricingPlanFeature>Unlimited sales tracking</PricingPlanFeature>
-          <PricingPlanFeature>Stripe payments integration</PricingPlanFeature>
           <PricingPlanFeature>A/B testing</PricingPlanFeature>
           <PricingPlanFeature>Webhooks &amp; API</PricingPlanFeature>
           <PricingPlanFeature>5 team members</PricingPlanFeature>
@@ -504,7 +502,6 @@ PIMMS is one of our daily allies to stay on track and turn our profile into a le
         <PricingPlanFeatureList>
           <PricingPlanFeature>1,000 links /month</PricingPlanFeature>
           <PricingPlanFeature>10k events tracked /month</PricingPlanFeature>
-          <PricingPlanFeature>Unlimited sales tracking</PricingPlanFeature>
           <PricingPlanFeature>5 custom domains</PricingPlanFeature>
           <PricingPlanFeature>Bulk link operations</PricingPlanFeature>
           <PricingPlanFeature>12 months of data</PricingPlanFeature>
@@ -518,7 +515,6 @@ PIMMS is one of our daily allies to stay on track and turn our profile into a le
         <PricingPlanFeatureList>
           <PricingPlanFeature>2,000 links /month</PricingPlanFeature>
           <PricingPlanFeature>20k events tracked /month</PricingPlanFeature>
-          <PricingPlanFeature>Unlimited sales tracking</PricingPlanFeature>
           <PricingPlanFeature>10 team members</PricingPlanFeature>
           <PricingPlanFeature>10 custom domains</PricingPlanFeature>
           <PricingPlanFeature>Bulk link operations</PricingPlanFeature>
@@ -527,6 +523,8 @@ PIMMS is one of our daily allies to stay on track and turn our profile into a le
         </PricingPlanFeatureList>
       </PricingPlanPanel>
     </PricingHero>
+
+    <Text size="sm" className="text-center mt-4"><a href="/pricing#compare" className="underline text-muted-foreground hover:text-foreground">Compare plans</a></Text>
   </Section>
 </Slide>
 

--- a/content/en/landings/webflow.mdx
+++ b/content/en/landings/webflow.mdx
@@ -475,7 +475,7 @@ PIMMS is one of our daily allies to stay on track and turn our profile into a le
         <PricingPlanFeatureListTitle>Everything in Free, plus:</PricingPlanFeatureListTitle>
         <PricingPlanFeatureList>
           <PricingPlanFeature>100 links /month</PricingPlanFeature>
-          <PricingPlanFeature>4,000 events tracked /month</PricingPlanFeature>
+          <PricingPlanFeature>1,500 events tracked /month</PricingPlanFeature>
           <PricingPlanFeature>1 custom domain</PricingPlanFeature>
           <PricingPlanFeature>Custom QR codes</PricingPlanFeature>
           <PricingPlanFeature>1 year of data</PricingPlanFeature>

--- a/content/en/landings/youtube.mdx
+++ b/content/en/landings/youtube.mdx
@@ -439,7 +439,7 @@ PIMMS is one of our daily allies to stay on track and turn our profile into a le
         <PricingPlanFeatureListTitle>Everything in Free, plus:</PricingPlanFeatureListTitle>
         <PricingPlanFeatureList>
           <PricingPlanFeature>100 links /month</PricingPlanFeature>
-          <PricingPlanFeature>Up to 1,500 clicks /month</PricingPlanFeature>
+          <PricingPlanFeature>4,000 events tracked /month</PricingPlanFeature>
           <PricingPlanFeature>1 custom domain</PricingPlanFeature>
           <PricingPlanFeature>Custom QR codes</PricingPlanFeature>
           <PricingPlanFeature>1 year of data</PricingPlanFeature>
@@ -452,8 +452,6 @@ PIMMS is one of our daily allies to stay on track and turn our profile into a le
         <PricingPlanFeatureListTitle>Everything in Tiny, plus:</PricingPlanFeatureListTitle>
         <PricingPlanFeatureList>
           <PricingPlanFeature>500 links /month</PricingPlanFeature>
-          <PricingPlanFeature>Unlimited sales tracking</PricingPlanFeature>
-          <PricingPlanFeature>Stripe payments integration</PricingPlanFeature>
           <PricingPlanFeature>A/B testing</PricingPlanFeature>
           <PricingPlanFeature>Webhooks &amp; API</PricingPlanFeature>
           <PricingPlanFeature>5 team members</PricingPlanFeature>
@@ -468,7 +466,6 @@ PIMMS is one of our daily allies to stay on track and turn our profile into a le
         <PricingPlanFeatureList>
           <PricingPlanFeature>1,000 links /month</PricingPlanFeature>
           <PricingPlanFeature>10k events tracked /month</PricingPlanFeature>
-          <PricingPlanFeature>Unlimited sales tracking</PricingPlanFeature>
           <PricingPlanFeature>5 custom domains</PricingPlanFeature>
           <PricingPlanFeature>Bulk link operations</PricingPlanFeature>
           <PricingPlanFeature>12 months of data</PricingPlanFeature>
@@ -482,7 +479,6 @@ PIMMS is one of our daily allies to stay on track and turn our profile into a le
         <PricingPlanFeatureList>
           <PricingPlanFeature>2,000 links /month</PricingPlanFeature>
           <PricingPlanFeature>20k events tracked /month</PricingPlanFeature>
-          <PricingPlanFeature>Unlimited sales tracking</PricingPlanFeature>
           <PricingPlanFeature>10 team members</PricingPlanFeature>
           <PricingPlanFeature>10 custom domains</PricingPlanFeature>
           <PricingPlanFeature>Bulk link operations</PricingPlanFeature>
@@ -491,6 +487,8 @@ PIMMS is one of our daily allies to stay on track and turn our profile into a le
         </PricingPlanFeatureList>
       </PricingPlanPanel>
     </PricingHero>
+
+    <Text size="sm" className="text-center mt-4"><a href="/pricing#compare" className="underline text-muted-foreground hover:text-foreground">Compare plans</a></Text>
   </Section>
 </Slide>
 

--- a/content/en/landings/youtube.mdx
+++ b/content/en/landings/youtube.mdx
@@ -439,7 +439,7 @@ PIMMS is one of our daily allies to stay on track and turn our profile into a le
         <PricingPlanFeatureListTitle>Everything in Free, plus:</PricingPlanFeatureListTitle>
         <PricingPlanFeatureList>
           <PricingPlanFeature>100 links /month</PricingPlanFeature>
-          <PricingPlanFeature>4,000 events tracked /month</PricingPlanFeature>
+          <PricingPlanFeature>1,500 events tracked /month</PricingPlanFeature>
           <PricingPlanFeature>1 custom domain</PricingPlanFeature>
           <PricingPlanFeature>Custom QR codes</PricingPlanFeature>
           <PricingPlanFeature>1 year of data</PricingPlanFeature>

--- a/content/fr/landings/brevo.mdx
+++ b/content/fr/landings/brevo.mdx
@@ -348,7 +348,7 @@ Avec PIMMS, tu as une vision claire. Simple. Sans complexité. Et en digital, ç
         <PricingPlanFeatureListTitle>Tout du Gratuit, plus :</PricingPlanFeatureListTitle>
         <PricingPlanFeatureList>
           <PricingPlanFeature>100 liens /mois</PricingPlanFeature>
-          <PricingPlanFeature>Jusqu'à 1 500 clics /mois</PricingPlanFeature>
+          <PricingPlanFeature>4 000 événements trackés /mois</PricingPlanFeature>
           <PricingPlanFeature>1 domaine personnalisé</PricingPlanFeature>
           <PricingPlanFeature>QR codes personnalisés</PricingPlanFeature>
           <PricingPlanFeature>1 an de données</PricingPlanFeature>
@@ -361,8 +361,6 @@ Avec PIMMS, tu as une vision claire. Simple. Sans complexité. Et en digital, ç
         <PricingPlanFeatureListTitle>Tout de Tiny, plus :</PricingPlanFeatureListTitle>
         <PricingPlanFeatureList>
           <PricingPlanFeature>500 liens /mois</PricingPlanFeature>
-          <PricingPlanFeature>Suivi des ventes illimité</PricingPlanFeature>
-          <PricingPlanFeature>Intégration paiements Stripe</PricingPlanFeature>
           <PricingPlanFeature>Tests A/B</PricingPlanFeature>
           <PricingPlanFeature>Webhooks &amp; API</PricingPlanFeature>
           <PricingPlanFeature>5 membres d'équipe</PricingPlanFeature>
@@ -377,7 +375,6 @@ Avec PIMMS, tu as une vision claire. Simple. Sans complexité. Et en digital, ç
         <PricingPlanFeatureList>
           <PricingPlanFeature>1 000 liens /mois</PricingPlanFeature>
           <PricingPlanFeature>10k événements suivis /mois</PricingPlanFeature>
-          <PricingPlanFeature>Suivi des ventes illimité</PricingPlanFeature>
           <PricingPlanFeature>5 domaines personnalisés</PricingPlanFeature>
           <PricingPlanFeature>Création de liens en masse</PricingPlanFeature>
           <PricingPlanFeature>12 mois de données</PricingPlanFeature>
@@ -391,7 +388,6 @@ Avec PIMMS, tu as une vision claire. Simple. Sans complexité. Et en digital, ç
         <PricingPlanFeatureList>
           <PricingPlanFeature>2 000 liens /mois</PricingPlanFeature>
           <PricingPlanFeature>20k événements suivis /mois</PricingPlanFeature>
-          <PricingPlanFeature>Suivi des ventes illimité</PricingPlanFeature>
           <PricingPlanFeature>10 membres d'équipe</PricingPlanFeature>
           <PricingPlanFeature>10 domaines personnalisés</PricingPlanFeature>
           <PricingPlanFeature>Création de liens en masse</PricingPlanFeature>
@@ -400,6 +396,8 @@ Avec PIMMS, tu as une vision claire. Simple. Sans complexité. Et en digital, ç
         </PricingPlanFeatureList>
       </PricingPlanPanel>
     </PricingHero>
+
+    <Text size="sm" className="text-center mt-4"><a href="/fr/pricing#compare" className="underline text-muted-foreground hover:text-foreground">Comparatif des plans</a></Text>
   </Section>
 </Slide>
 

--- a/content/fr/landings/brevo.mdx
+++ b/content/fr/landings/brevo.mdx
@@ -348,7 +348,7 @@ Avec PIMMS, tu as une vision claire. Simple. Sans complexité. Et en digital, ç
         <PricingPlanFeatureListTitle>Tout du Gratuit, plus :</PricingPlanFeatureListTitle>
         <PricingPlanFeatureList>
           <PricingPlanFeature>100 liens /mois</PricingPlanFeature>
-          <PricingPlanFeature>4 000 événements trackés /mois</PricingPlanFeature>
+          <PricingPlanFeature>1 500 événements trackés /mois</PricingPlanFeature>
           <PricingPlanFeature>1 domaine personnalisé</PricingPlanFeature>
           <PricingPlanFeature>QR codes personnalisés</PricingPlanFeature>
           <PricingPlanFeature>1 an de données</PricingPlanFeature>

--- a/content/fr/landings/calcom.mdx
+++ b/content/fr/landings/calcom.mdx
@@ -348,7 +348,7 @@ Avec PIMMS, tu as une vision claire. Simple. Sans complexité. Et en digital, ç
         <PricingPlanFeatureListTitle>Tout du Gratuit, plus :</PricingPlanFeatureListTitle>
         <PricingPlanFeatureList>
           <PricingPlanFeature>100 liens /mois</PricingPlanFeature>
-          <PricingPlanFeature>Jusqu'à 1 500 clics /mois</PricingPlanFeature>
+          <PricingPlanFeature>4 000 événements trackés /mois</PricingPlanFeature>
           <PricingPlanFeature>1 domaine personnalisé</PricingPlanFeature>
           <PricingPlanFeature>QR codes personnalisés</PricingPlanFeature>
           <PricingPlanFeature>1 an de données</PricingPlanFeature>
@@ -361,8 +361,6 @@ Avec PIMMS, tu as une vision claire. Simple. Sans complexité. Et en digital, ç
         <PricingPlanFeatureListTitle>Tout de Tiny, plus :</PricingPlanFeatureListTitle>
         <PricingPlanFeatureList>
           <PricingPlanFeature>500 liens /mois</PricingPlanFeature>
-          <PricingPlanFeature>Suivi des ventes illimité</PricingPlanFeature>
-          <PricingPlanFeature>Intégration paiements Stripe</PricingPlanFeature>
           <PricingPlanFeature>Tests A/B</PricingPlanFeature>
           <PricingPlanFeature>Webhooks &amp; API</PricingPlanFeature>
           <PricingPlanFeature>5 membres d'équipe</PricingPlanFeature>
@@ -377,7 +375,6 @@ Avec PIMMS, tu as une vision claire. Simple. Sans complexité. Et en digital, ç
         <PricingPlanFeatureList>
           <PricingPlanFeature>1 000 liens /mois</PricingPlanFeature>
           <PricingPlanFeature>10k événements suivis /mois</PricingPlanFeature>
-          <PricingPlanFeature>Suivi des ventes illimité</PricingPlanFeature>
           <PricingPlanFeature>5 domaines personnalisés</PricingPlanFeature>
           <PricingPlanFeature>Création de liens en masse</PricingPlanFeature>
           <PricingPlanFeature>12 mois de données</PricingPlanFeature>
@@ -391,7 +388,6 @@ Avec PIMMS, tu as une vision claire. Simple. Sans complexité. Et en digital, ç
         <PricingPlanFeatureList>
           <PricingPlanFeature>2 000 liens /mois</PricingPlanFeature>
           <PricingPlanFeature>20k événements suivis /mois</PricingPlanFeature>
-          <PricingPlanFeature>Suivi des ventes illimité</PricingPlanFeature>
           <PricingPlanFeature>10 membres d'équipe</PricingPlanFeature>
           <PricingPlanFeature>10 domaines personnalisés</PricingPlanFeature>
           <PricingPlanFeature>Création de liens en masse</PricingPlanFeature>
@@ -400,6 +396,8 @@ Avec PIMMS, tu as une vision claire. Simple. Sans complexité. Et en digital, ç
         </PricingPlanFeatureList>
       </PricingPlanPanel>
     </PricingHero>
+
+    <Text size="sm" className="text-center mt-4"><a href="/fr/pricing#compare" className="underline text-muted-foreground hover:text-foreground">Comparatif des plans</a></Text>
   </Section>
 </Slide>
 

--- a/content/fr/landings/calcom.mdx
+++ b/content/fr/landings/calcom.mdx
@@ -348,7 +348,7 @@ Avec PIMMS, tu as une vision claire. Simple. Sans complexité. Et en digital, ç
         <PricingPlanFeatureListTitle>Tout du Gratuit, plus :</PricingPlanFeatureListTitle>
         <PricingPlanFeatureList>
           <PricingPlanFeature>100 liens /mois</PricingPlanFeature>
-          <PricingPlanFeature>4 000 événements trackés /mois</PricingPlanFeature>
+          <PricingPlanFeature>1 500 événements trackés /mois</PricingPlanFeature>
           <PricingPlanFeature>1 domaine personnalisé</PricingPlanFeature>
           <PricingPlanFeature>QR codes personnalisés</PricingPlanFeature>
           <PricingPlanFeature>1 an de données</PricingPlanFeature>

--- a/content/fr/landings/calendly.mdx
+++ b/content/fr/landings/calendly.mdx
@@ -348,7 +348,7 @@ Avec PIMMS, tu as une vision claire. Simple. Sans complexité. Et en digital, ç
         <PricingPlanFeatureListTitle>Tout du Gratuit, plus :</PricingPlanFeatureListTitle>
         <PricingPlanFeatureList>
           <PricingPlanFeature>100 liens /mois</PricingPlanFeature>
-          <PricingPlanFeature>Jusqu'à 1 500 clics /mois</PricingPlanFeature>
+          <PricingPlanFeature>4 000 événements trackés /mois</PricingPlanFeature>
           <PricingPlanFeature>1 domaine personnalisé</PricingPlanFeature>
           <PricingPlanFeature>QR codes personnalisés</PricingPlanFeature>
           <PricingPlanFeature>1 an de données</PricingPlanFeature>
@@ -361,8 +361,6 @@ Avec PIMMS, tu as une vision claire. Simple. Sans complexité. Et en digital, ç
         <PricingPlanFeatureListTitle>Tout de Tiny, plus :</PricingPlanFeatureListTitle>
         <PricingPlanFeatureList>
           <PricingPlanFeature>500 liens /mois</PricingPlanFeature>
-          <PricingPlanFeature>Suivi des ventes illimité</PricingPlanFeature>
-          <PricingPlanFeature>Intégration paiements Stripe</PricingPlanFeature>
           <PricingPlanFeature>Tests A/B</PricingPlanFeature>
           <PricingPlanFeature>Webhooks &amp; API</PricingPlanFeature>
           <PricingPlanFeature>5 membres d'équipe</PricingPlanFeature>
@@ -377,7 +375,6 @@ Avec PIMMS, tu as une vision claire. Simple. Sans complexité. Et en digital, ç
         <PricingPlanFeatureList>
           <PricingPlanFeature>1 000 liens /mois</PricingPlanFeature>
           <PricingPlanFeature>10k événements suivis /mois</PricingPlanFeature>
-          <PricingPlanFeature>Suivi des ventes illimité</PricingPlanFeature>
           <PricingPlanFeature>5 domaines personnalisés</PricingPlanFeature>
           <PricingPlanFeature>Création de liens en masse</PricingPlanFeature>
           <PricingPlanFeature>12 mois de données</PricingPlanFeature>
@@ -391,7 +388,6 @@ Avec PIMMS, tu as une vision claire. Simple. Sans complexité. Et en digital, ç
         <PricingPlanFeatureList>
           <PricingPlanFeature>2 000 liens /mois</PricingPlanFeature>
           <PricingPlanFeature>20k événements suivis /mois</PricingPlanFeature>
-          <PricingPlanFeature>Suivi des ventes illimité</PricingPlanFeature>
           <PricingPlanFeature>10 membres d'équipe</PricingPlanFeature>
           <PricingPlanFeature>10 domaines personnalisés</PricingPlanFeature>
           <PricingPlanFeature>Création de liens en masse</PricingPlanFeature>
@@ -400,6 +396,8 @@ Avec PIMMS, tu as une vision claire. Simple. Sans complexité. Et en digital, ç
         </PricingPlanFeatureList>
       </PricingPlanPanel>
     </PricingHero>
+
+    <Text size="sm" className="text-center mt-4"><a href="/fr/pricing#compare" className="underline text-muted-foreground hover:text-foreground">Comparatif des plans</a></Text>
   </Section>
 </Slide>
 

--- a/content/fr/landings/calendly.mdx
+++ b/content/fr/landings/calendly.mdx
@@ -348,7 +348,7 @@ Avec PIMMS, tu as une vision claire. Simple. Sans complexité. Et en digital, ç
         <PricingPlanFeatureListTitle>Tout du Gratuit, plus :</PricingPlanFeatureListTitle>
         <PricingPlanFeatureList>
           <PricingPlanFeature>100 liens /mois</PricingPlanFeature>
-          <PricingPlanFeature>4 000 événements trackés /mois</PricingPlanFeature>
+          <PricingPlanFeature>1 500 événements trackés /mois</PricingPlanFeature>
           <PricingPlanFeature>1 domaine personnalisé</PricingPlanFeature>
           <PricingPlanFeature>QR codes personnalisés</PricingPlanFeature>
           <PricingPlanFeature>1 an de données</PricingPlanFeature>

--- a/content/fr/landings/elementor.mdx
+++ b/content/fr/landings/elementor.mdx
@@ -348,7 +348,7 @@ Avec PIMMS, tu as une vision claire. Simple. Sans complexité. Et en digital, ç
         <PricingPlanFeatureListTitle>Tout du Gratuit, plus :</PricingPlanFeatureListTitle>
         <PricingPlanFeatureList>
           <PricingPlanFeature>100 liens /mois</PricingPlanFeature>
-          <PricingPlanFeature>Jusqu'à 1 500 clics /mois</PricingPlanFeature>
+          <PricingPlanFeature>4 000 événements trackés /mois</PricingPlanFeature>
           <PricingPlanFeature>1 domaine personnalisé</PricingPlanFeature>
           <PricingPlanFeature>QR codes personnalisés</PricingPlanFeature>
           <PricingPlanFeature>1 an de données</PricingPlanFeature>
@@ -361,8 +361,6 @@ Avec PIMMS, tu as une vision claire. Simple. Sans complexité. Et en digital, ç
         <PricingPlanFeatureListTitle>Tout de Tiny, plus :</PricingPlanFeatureListTitle>
         <PricingPlanFeatureList>
           <PricingPlanFeature>500 liens /mois</PricingPlanFeature>
-          <PricingPlanFeature>Suivi des ventes illimité</PricingPlanFeature>
-          <PricingPlanFeature>Intégration paiements Stripe</PricingPlanFeature>
           <PricingPlanFeature>Tests A/B</PricingPlanFeature>
           <PricingPlanFeature>Webhooks &amp; API</PricingPlanFeature>
           <PricingPlanFeature>5 membres d'équipe</PricingPlanFeature>
@@ -377,7 +375,6 @@ Avec PIMMS, tu as une vision claire. Simple. Sans complexité. Et en digital, ç
         <PricingPlanFeatureList>
           <PricingPlanFeature>1 000 liens /mois</PricingPlanFeature>
           <PricingPlanFeature>10k événements suivis /mois</PricingPlanFeature>
-          <PricingPlanFeature>Suivi des ventes illimité</PricingPlanFeature>
           <PricingPlanFeature>5 domaines personnalisés</PricingPlanFeature>
           <PricingPlanFeature>Création de liens en masse</PricingPlanFeature>
           <PricingPlanFeature>12 mois de données</PricingPlanFeature>
@@ -391,7 +388,6 @@ Avec PIMMS, tu as une vision claire. Simple. Sans complexité. Et en digital, ç
         <PricingPlanFeatureList>
           <PricingPlanFeature>2 000 liens /mois</PricingPlanFeature>
           <PricingPlanFeature>20k événements suivis /mois</PricingPlanFeature>
-          <PricingPlanFeature>Suivi des ventes illimité</PricingPlanFeature>
           <PricingPlanFeature>10 membres d'équipe</PricingPlanFeature>
           <PricingPlanFeature>10 domaines personnalisés</PricingPlanFeature>
           <PricingPlanFeature>Création de liens en masse</PricingPlanFeature>
@@ -400,6 +396,8 @@ Avec PIMMS, tu as une vision claire. Simple. Sans complexité. Et en digital, ç
         </PricingPlanFeatureList>
       </PricingPlanPanel>
     </PricingHero>
+
+    <Text size="sm" className="text-center mt-4"><a href="/fr/pricing#compare" className="underline text-muted-foreground hover:text-foreground">Comparatif des plans</a></Text>
   </Section>
 </Slide>
 

--- a/content/fr/landings/elementor.mdx
+++ b/content/fr/landings/elementor.mdx
@@ -348,7 +348,7 @@ Avec PIMMS, tu as une vision claire. Simple. Sans complexité. Et en digital, ç
         <PricingPlanFeatureListTitle>Tout du Gratuit, plus :</PricingPlanFeatureListTitle>
         <PricingPlanFeatureList>
           <PricingPlanFeature>100 liens /mois</PricingPlanFeature>
-          <PricingPlanFeature>4 000 événements trackés /mois</PricingPlanFeature>
+          <PricingPlanFeature>1 500 événements trackés /mois</PricingPlanFeature>
           <PricingPlanFeature>1 domaine personnalisé</PricingPlanFeature>
           <PricingPlanFeature>QR codes personnalisés</PricingPlanFeature>
           <PricingPlanFeature>1 an de données</PricingPlanFeature>

--- a/content/fr/landings/framer.mdx
+++ b/content/fr/landings/framer.mdx
@@ -348,7 +348,7 @@ Avec PIMMS, tu as une vision claire. Simple. Sans complexité. Et en digital, ç
         <PricingPlanFeatureListTitle>Tout du Gratuit, plus :</PricingPlanFeatureListTitle>
         <PricingPlanFeatureList>
           <PricingPlanFeature>100 liens /mois</PricingPlanFeature>
-          <PricingPlanFeature>Jusqu'à 1 500 clics /mois</PricingPlanFeature>
+          <PricingPlanFeature>4 000 événements trackés /mois</PricingPlanFeature>
           <PricingPlanFeature>1 domaine personnalisé</PricingPlanFeature>
           <PricingPlanFeature>QR codes personnalisés</PricingPlanFeature>
           <PricingPlanFeature>1 an de données</PricingPlanFeature>
@@ -361,8 +361,6 @@ Avec PIMMS, tu as une vision claire. Simple. Sans complexité. Et en digital, ç
         <PricingPlanFeatureListTitle>Tout de Tiny, plus :</PricingPlanFeatureListTitle>
         <PricingPlanFeatureList>
           <PricingPlanFeature>500 liens /mois</PricingPlanFeature>
-          <PricingPlanFeature>Suivi des ventes illimité</PricingPlanFeature>
-          <PricingPlanFeature>Intégration paiements Stripe</PricingPlanFeature>
           <PricingPlanFeature>Tests A/B</PricingPlanFeature>
           <PricingPlanFeature>Webhooks &amp; API</PricingPlanFeature>
           <PricingPlanFeature>5 membres d'équipe</PricingPlanFeature>
@@ -377,7 +375,6 @@ Avec PIMMS, tu as une vision claire. Simple. Sans complexité. Et en digital, ç
         <PricingPlanFeatureList>
           <PricingPlanFeature>1 000 liens /mois</PricingPlanFeature>
           <PricingPlanFeature>10k événements suivis /mois</PricingPlanFeature>
-          <PricingPlanFeature>Suivi des ventes illimité</PricingPlanFeature>
           <PricingPlanFeature>5 domaines personnalisés</PricingPlanFeature>
           <PricingPlanFeature>Création de liens en masse</PricingPlanFeature>
           <PricingPlanFeature>12 mois de données</PricingPlanFeature>
@@ -391,7 +388,6 @@ Avec PIMMS, tu as une vision claire. Simple. Sans complexité. Et en digital, ç
         <PricingPlanFeatureList>
           <PricingPlanFeature>2 000 liens /mois</PricingPlanFeature>
           <PricingPlanFeature>20k événements suivis /mois</PricingPlanFeature>
-          <PricingPlanFeature>Suivi des ventes illimité</PricingPlanFeature>
           <PricingPlanFeature>10 membres d'équipe</PricingPlanFeature>
           <PricingPlanFeature>10 domaines personnalisés</PricingPlanFeature>
           <PricingPlanFeature>Création de liens en masse</PricingPlanFeature>
@@ -400,6 +396,8 @@ Avec PIMMS, tu as une vision claire. Simple. Sans complexité. Et en digital, ç
         </PricingPlanFeatureList>
       </PricingPlanPanel>
     </PricingHero>
+
+    <Text size="sm" className="text-center mt-4"><a href="/fr/pricing#compare" className="underline text-muted-foreground hover:text-foreground">Comparatif des plans</a></Text>
   </Section>
 </Slide>
 

--- a/content/fr/landings/framer.mdx
+++ b/content/fr/landings/framer.mdx
@@ -348,7 +348,7 @@ Avec PIMMS, tu as une vision claire. Simple. Sans complexité. Et en digital, ç
         <PricingPlanFeatureListTitle>Tout du Gratuit, plus :</PricingPlanFeatureListTitle>
         <PricingPlanFeatureList>
           <PricingPlanFeature>100 liens /mois</PricingPlanFeature>
-          <PricingPlanFeature>4 000 événements trackés /mois</PricingPlanFeature>
+          <PricingPlanFeature>1 500 événements trackés /mois</PricingPlanFeature>
           <PricingPlanFeature>1 domaine personnalisé</PricingPlanFeature>
           <PricingPlanFeature>QR codes personnalisés</PricingPlanFeature>
           <PricingPlanFeature>1 an de données</PricingPlanFeature>

--- a/content/fr/landings/home.mdx
+++ b/content/fr/landings/home.mdx
@@ -443,7 +443,7 @@ PIMMS est un de nos alliés du quotidien pour garder le cap et transformer notre
         <PricingPlanFeatureListTitle>Tout du Gratuit, plus :</PricingPlanFeatureListTitle>
         <PricingPlanFeatureList>
           <PricingPlanFeature>100 liens /mois</PricingPlanFeature>
-          <PricingPlanFeature>Jusqu'à 1 500 clics /mois</PricingPlanFeature>
+          <PricingPlanFeature>4 000 événements trackés /mois</PricingPlanFeature>
           <PricingPlanFeature>1 domaine personnalisé</PricingPlanFeature>
           <PricingPlanFeature>QR codes personnalisés</PricingPlanFeature>
           <PricingPlanFeature>1 an de données</PricingPlanFeature>
@@ -456,8 +456,6 @@ PIMMS est un de nos alliés du quotidien pour garder le cap et transformer notre
         <PricingPlanFeatureListTitle>Tout de Tiny, plus :</PricingPlanFeatureListTitle>
         <PricingPlanFeatureList>
           <PricingPlanFeature>500 liens /mois</PricingPlanFeature>
-          <PricingPlanFeature>Suivi des ventes illimité</PricingPlanFeature>
-          <PricingPlanFeature>Intégration paiements Stripe</PricingPlanFeature>
           <PricingPlanFeature>Tests A/B</PricingPlanFeature>
           <PricingPlanFeature>Webhooks &amp; API</PricingPlanFeature>
           <PricingPlanFeature>5 membres d'équipe</PricingPlanFeature>
@@ -472,7 +470,6 @@ PIMMS est un de nos alliés du quotidien pour garder le cap et transformer notre
         <PricingPlanFeatureList>
           <PricingPlanFeature>1 000 liens /mois</PricingPlanFeature>
           <PricingPlanFeature>10k événements suivis /mois</PricingPlanFeature>
-          <PricingPlanFeature>Suivi des ventes illimité</PricingPlanFeature>
           <PricingPlanFeature>5 domaines personnalisés</PricingPlanFeature>
           <PricingPlanFeature>Création de liens en masse</PricingPlanFeature>
           <PricingPlanFeature>12 mois de données</PricingPlanFeature>
@@ -486,7 +483,6 @@ PIMMS est un de nos alliés du quotidien pour garder le cap et transformer notre
         <PricingPlanFeatureList>
           <PricingPlanFeature>2 000 liens /mois</PricingPlanFeature>
           <PricingPlanFeature>20k événements suivis /mois</PricingPlanFeature>
-          <PricingPlanFeature>Suivi des ventes illimité</PricingPlanFeature>
           <PricingPlanFeature>10 membres d'équipe</PricingPlanFeature>
           <PricingPlanFeature>10 domaines personnalisés</PricingPlanFeature>
           <PricingPlanFeature>Création de liens en masse</PricingPlanFeature>
@@ -495,6 +491,8 @@ PIMMS est un de nos alliés du quotidien pour garder le cap et transformer notre
         </PricingPlanFeatureList>
       </PricingPlanPanel>
     </PricingHero>
+
+    <Text size="sm" className="text-center mt-4"><a href="/fr/pricing#compare" className="underline text-muted-foreground hover:text-foreground">Comparatif des plans</a></Text>
   </Section>
 </Slide>
 

--- a/content/fr/landings/home.mdx
+++ b/content/fr/landings/home.mdx
@@ -443,7 +443,7 @@ PIMMS est un de nos alliés du quotidien pour garder le cap et transformer notre
         <PricingPlanFeatureListTitle>Tout du Gratuit, plus :</PricingPlanFeatureListTitle>
         <PricingPlanFeatureList>
           <PricingPlanFeature>100 liens /mois</PricingPlanFeature>
-          <PricingPlanFeature>4 000 événements trackés /mois</PricingPlanFeature>
+          <PricingPlanFeature>1 500 événements trackés /mois</PricingPlanFeature>
           <PricingPlanFeature>1 domaine personnalisé</PricingPlanFeature>
           <PricingPlanFeature>QR codes personnalisés</PricingPlanFeature>
           <PricingPlanFeature>1 an de données</PricingPlanFeature>

--- a/content/fr/landings/iclosed.mdx
+++ b/content/fr/landings/iclosed.mdx
@@ -348,7 +348,7 @@ Avec PIMMS, tu as une vision claire. Simple. Sans complexité. Et en digital, ç
         <PricingPlanFeatureListTitle>Tout du Gratuit, plus :</PricingPlanFeatureListTitle>
         <PricingPlanFeatureList>
           <PricingPlanFeature>100 liens /mois</PricingPlanFeature>
-          <PricingPlanFeature>Jusqu'à 1 500 clics /mois</PricingPlanFeature>
+          <PricingPlanFeature>4 000 événements trackés /mois</PricingPlanFeature>
           <PricingPlanFeature>1 domaine personnalisé</PricingPlanFeature>
           <PricingPlanFeature>QR codes personnalisés</PricingPlanFeature>
           <PricingPlanFeature>1 an de données</PricingPlanFeature>
@@ -361,8 +361,6 @@ Avec PIMMS, tu as une vision claire. Simple. Sans complexité. Et en digital, ç
         <PricingPlanFeatureListTitle>Tout de Tiny, plus :</PricingPlanFeatureListTitle>
         <PricingPlanFeatureList>
           <PricingPlanFeature>500 liens /mois</PricingPlanFeature>
-          <PricingPlanFeature>Suivi des ventes illimité</PricingPlanFeature>
-          <PricingPlanFeature>Intégration paiements Stripe</PricingPlanFeature>
           <PricingPlanFeature>Tests A/B</PricingPlanFeature>
           <PricingPlanFeature>Webhooks &amp; API</PricingPlanFeature>
           <PricingPlanFeature>5 membres d'équipe</PricingPlanFeature>
@@ -377,7 +375,6 @@ Avec PIMMS, tu as une vision claire. Simple. Sans complexité. Et en digital, ç
         <PricingPlanFeatureList>
           <PricingPlanFeature>1 000 liens /mois</PricingPlanFeature>
           <PricingPlanFeature>10k événements suivis /mois</PricingPlanFeature>
-          <PricingPlanFeature>Suivi des ventes illimité</PricingPlanFeature>
           <PricingPlanFeature>5 domaines personnalisés</PricingPlanFeature>
           <PricingPlanFeature>Création de liens en masse</PricingPlanFeature>
           <PricingPlanFeature>12 mois de données</PricingPlanFeature>
@@ -391,7 +388,6 @@ Avec PIMMS, tu as une vision claire. Simple. Sans complexité. Et en digital, ç
         <PricingPlanFeatureList>
           <PricingPlanFeature>2 000 liens /mois</PricingPlanFeature>
           <PricingPlanFeature>20k événements suivis /mois</PricingPlanFeature>
-          <PricingPlanFeature>Suivi des ventes illimité</PricingPlanFeature>
           <PricingPlanFeature>10 membres d'équipe</PricingPlanFeature>
           <PricingPlanFeature>10 domaines personnalisés</PricingPlanFeature>
           <PricingPlanFeature>Création de liens en masse</PricingPlanFeature>
@@ -400,6 +396,8 @@ Avec PIMMS, tu as une vision claire. Simple. Sans complexité. Et en digital, ç
         </PricingPlanFeatureList>
       </PricingPlanPanel>
     </PricingHero>
+
+    <Text size="sm" className="text-center mt-4"><a href="/fr/pricing#compare" className="underline text-muted-foreground hover:text-foreground">Comparatif des plans</a></Text>
   </Section>
 </Slide>
 

--- a/content/fr/landings/iclosed.mdx
+++ b/content/fr/landings/iclosed.mdx
@@ -348,7 +348,7 @@ Avec PIMMS, tu as une vision claire. Simple. Sans complexité. Et en digital, ç
         <PricingPlanFeatureListTitle>Tout du Gratuit, plus :</PricingPlanFeatureListTitle>
         <PricingPlanFeatureList>
           <PricingPlanFeature>100 liens /mois</PricingPlanFeature>
-          <PricingPlanFeature>4 000 événements trackés /mois</PricingPlanFeature>
+          <PricingPlanFeature>1 500 événements trackés /mois</PricingPlanFeature>
           <PricingPlanFeature>1 domaine personnalisé</PricingPlanFeature>
           <PricingPlanFeature>QR codes personnalisés</PricingPlanFeature>
           <PricingPlanFeature>1 an de données</PricingPlanFeature>

--- a/content/fr/landings/landing-page-tracking.mdx
+++ b/content/fr/landings/landing-page-tracking.mdx
@@ -412,7 +412,7 @@ Simple, propre, efficace. PS : C'est mieux que la concurrence.
         <PricingPlanFeatureListTitle>Tout du Gratuit, plus :</PricingPlanFeatureListTitle>
         <PricingPlanFeatureList>
           <PricingPlanFeature>100 liens /mois</PricingPlanFeature>
-          <PricingPlanFeature>4 000 événements trackés /mois</PricingPlanFeature>
+          <PricingPlanFeature>1 500 événements trackés /mois</PricingPlanFeature>
           <PricingPlanFeature>1 domaine personnalisé</PricingPlanFeature>
           <PricingPlanFeature>QR codes personnalisés</PricingPlanFeature>
           <PricingPlanFeature>1 an de données</PricingPlanFeature>

--- a/content/fr/landings/landing-page-tracking.mdx
+++ b/content/fr/landings/landing-page-tracking.mdx
@@ -412,7 +412,7 @@ Simple, propre, efficace. PS : C'est mieux que la concurrence.
         <PricingPlanFeatureListTitle>Tout du Gratuit, plus :</PricingPlanFeatureListTitle>
         <PricingPlanFeatureList>
           <PricingPlanFeature>100 liens /mois</PricingPlanFeature>
-          <PricingPlanFeature>Jusqu'à 1 500 clics /mois</PricingPlanFeature>
+          <PricingPlanFeature>4 000 événements trackés /mois</PricingPlanFeature>
           <PricingPlanFeature>1 domaine personnalisé</PricingPlanFeature>
           <PricingPlanFeature>QR codes personnalisés</PricingPlanFeature>
           <PricingPlanFeature>1 an de données</PricingPlanFeature>
@@ -425,8 +425,6 @@ Simple, propre, efficace. PS : C'est mieux que la concurrence.
         <PricingPlanFeatureListTitle>Tout de Tiny, plus :</PricingPlanFeatureListTitle>
         <PricingPlanFeatureList>
           <PricingPlanFeature>500 liens /mois</PricingPlanFeature>
-          <PricingPlanFeature>Suivi des ventes illimité</PricingPlanFeature>
-          <PricingPlanFeature>Intégration paiements Stripe</PricingPlanFeature>
           <PricingPlanFeature>Tests A/B</PricingPlanFeature>
           <PricingPlanFeature>Webhooks &amp; API</PricingPlanFeature>
           <PricingPlanFeature>5 membres d'équipe</PricingPlanFeature>
@@ -441,7 +439,6 @@ Simple, propre, efficace. PS : C'est mieux que la concurrence.
         <PricingPlanFeatureList>
           <PricingPlanFeature>1 000 liens /mois</PricingPlanFeature>
           <PricingPlanFeature>10k événements suivis /mois</PricingPlanFeature>
-          <PricingPlanFeature>Suivi des ventes illimité</PricingPlanFeature>
           <PricingPlanFeature>5 domaines personnalisés</PricingPlanFeature>
           <PricingPlanFeature>Création de liens en masse</PricingPlanFeature>
           <PricingPlanFeature>12 mois de données</PricingPlanFeature>
@@ -455,7 +452,6 @@ Simple, propre, efficace. PS : C'est mieux que la concurrence.
         <PricingPlanFeatureList>
           <PricingPlanFeature>2 000 liens /mois</PricingPlanFeature>
           <PricingPlanFeature>20k événements suivis /mois</PricingPlanFeature>
-          <PricingPlanFeature>Suivi des ventes illimité</PricingPlanFeature>
           <PricingPlanFeature>10 membres d'équipe</PricingPlanFeature>
           <PricingPlanFeature>10 domaines personnalisés</PricingPlanFeature>
           <PricingPlanFeature>Création de liens en masse</PricingPlanFeature>
@@ -464,6 +460,8 @@ Simple, propre, efficace. PS : C'est mieux que la concurrence.
         </PricingPlanFeatureList>
       </PricingPlanPanel>
     </PricingHero>
+
+    <Text size="sm" className="text-center mt-4"><a href="/fr/pricing#compare" className="underline text-muted-foreground hover:text-foreground">Comparatif des plans</a></Text>
   </Section>
 </Slide>
 

--- a/content/fr/landings/linkedin-tracker.mdx
+++ b/content/fr/landings/linkedin-tracker.mdx
@@ -298,7 +298,7 @@ Et quand je mets en ligne une nouvelle page, si le visiteur est identifié dans 
         <PricingPlanFeatureListTitle>Tout du Gratuit, plus :</PricingPlanFeatureListTitle>
         <PricingPlanFeatureList>
           <PricingPlanFeature>100 liens /mois</PricingPlanFeature>
-          <PricingPlanFeature>Jusqu'à 1 500 clics /mois</PricingPlanFeature>
+          <PricingPlanFeature>4 000 événements trackés /mois</PricingPlanFeature>
           <PricingPlanFeature>1 domaine personnalisé</PricingPlanFeature>
           <PricingPlanFeature>QR codes personnalisés</PricingPlanFeature>
           <PricingPlanFeature>1 an de données</PricingPlanFeature>
@@ -311,8 +311,6 @@ Et quand je mets en ligne une nouvelle page, si le visiteur est identifié dans 
         <PricingPlanFeatureListTitle>Tout de Tiny, plus :</PricingPlanFeatureListTitle>
         <PricingPlanFeatureList>
           <PricingPlanFeature>500 liens /mois</PricingPlanFeature>
-          <PricingPlanFeature>Suivi des ventes illimité</PricingPlanFeature>
-          <PricingPlanFeature>Intégration paiements Stripe</PricingPlanFeature>
           <PricingPlanFeature>Tests A/B</PricingPlanFeature>
           <PricingPlanFeature>Webhooks &amp; API</PricingPlanFeature>
           <PricingPlanFeature>5 membres d'équipe</PricingPlanFeature>
@@ -327,7 +325,6 @@ Et quand je mets en ligne une nouvelle page, si le visiteur est identifié dans 
         <PricingPlanFeatureList>
           <PricingPlanFeature>1 000 liens /mois</PricingPlanFeature>
           <PricingPlanFeature>10k événements suivis /mois</PricingPlanFeature>
-          <PricingPlanFeature>Suivi des ventes illimité</PricingPlanFeature>
           <PricingPlanFeature>5 domaines personnalisés</PricingPlanFeature>
           <PricingPlanFeature>Création de liens en masse</PricingPlanFeature>
           <PricingPlanFeature>12 mois de données</PricingPlanFeature>
@@ -341,7 +338,6 @@ Et quand je mets en ligne une nouvelle page, si le visiteur est identifié dans 
         <PricingPlanFeatureList>
           <PricingPlanFeature>2 000 liens /mois</PricingPlanFeature>
           <PricingPlanFeature>20k événements suivis /mois</PricingPlanFeature>
-          <PricingPlanFeature>Suivi des ventes illimité</PricingPlanFeature>
           <PricingPlanFeature>10 membres d'équipe</PricingPlanFeature>
           <PricingPlanFeature>10 domaines personnalisés</PricingPlanFeature>
           <PricingPlanFeature>Création de liens en masse</PricingPlanFeature>
@@ -350,6 +346,8 @@ Et quand je mets en ligne une nouvelle page, si le visiteur est identifié dans 
         </PricingPlanFeatureList>
       </PricingPlanPanel>
     </PricingHero>
+
+    <Text size="sm" className="text-center mt-4"><a href="/fr/pricing#compare" className="underline text-muted-foreground hover:text-foreground">Comparatif des plans</a></Text>
   </Section>
 </Slide>
 

--- a/content/fr/landings/linkedin-tracker.mdx
+++ b/content/fr/landings/linkedin-tracker.mdx
@@ -298,7 +298,7 @@ Et quand je mets en ligne une nouvelle page, si le visiteur est identifié dans 
         <PricingPlanFeatureListTitle>Tout du Gratuit, plus :</PricingPlanFeatureListTitle>
         <PricingPlanFeatureList>
           <PricingPlanFeature>100 liens /mois</PricingPlanFeature>
-          <PricingPlanFeature>4 000 événements trackés /mois</PricingPlanFeature>
+          <PricingPlanFeature>1 500 événements trackés /mois</PricingPlanFeature>
           <PricingPlanFeature>1 domaine personnalisé</PricingPlanFeature>
           <PricingPlanFeature>QR codes personnalisés</PricingPlanFeature>
           <PricingPlanFeature>1 an de données</PricingPlanFeature>

--- a/content/fr/landings/podia.mdx
+++ b/content/fr/landings/podia.mdx
@@ -308,7 +308,7 @@ Avec PIMMS, tu as une vision claire. Simple. Sans complexité. Et en digital, ç
         <PricingPlanFeatureListTitle>Tout du Gratuit, plus :</PricingPlanFeatureListTitle>
         <PricingPlanFeatureList>
           <PricingPlanFeature>100 liens /mois</PricingPlanFeature>
-          <PricingPlanFeature>4 000 événements trackés /mois</PricingPlanFeature>
+          <PricingPlanFeature>1 500 événements trackés /mois</PricingPlanFeature>
           <PricingPlanFeature>1 domaine personnalisé</PricingPlanFeature>
           <PricingPlanFeature>QR codes personnalisés</PricingPlanFeature>
           <PricingPlanFeature>1 an de données</PricingPlanFeature>

--- a/content/fr/landings/podia.mdx
+++ b/content/fr/landings/podia.mdx
@@ -308,7 +308,7 @@ Avec PIMMS, tu as une vision claire. Simple. Sans complexité. Et en digital, ç
         <PricingPlanFeatureListTitle>Tout du Gratuit, plus :</PricingPlanFeatureListTitle>
         <PricingPlanFeatureList>
           <PricingPlanFeature>100 liens /mois</PricingPlanFeature>
-          <PricingPlanFeature>Jusqu'à 1 500 clics /mois</PricingPlanFeature>
+          <PricingPlanFeature>4 000 événements trackés /mois</PricingPlanFeature>
           <PricingPlanFeature>1 domaine personnalisé</PricingPlanFeature>
           <PricingPlanFeature>QR codes personnalisés</PricingPlanFeature>
           <PricingPlanFeature>1 an de données</PricingPlanFeature>
@@ -321,8 +321,6 @@ Avec PIMMS, tu as une vision claire. Simple. Sans complexité. Et en digital, ç
         <PricingPlanFeatureListTitle>Tout de Tiny, plus :</PricingPlanFeatureListTitle>
         <PricingPlanFeatureList>
           <PricingPlanFeature>500 liens /mois</PricingPlanFeature>
-          <PricingPlanFeature>Suivi des ventes illimité</PricingPlanFeature>
-          <PricingPlanFeature>Intégration paiements Stripe</PricingPlanFeature>
           <PricingPlanFeature>Tests A/B</PricingPlanFeature>
           <PricingPlanFeature>Webhooks &amp; API</PricingPlanFeature>
           <PricingPlanFeature>5 membres d'équipe</PricingPlanFeature>
@@ -337,7 +335,6 @@ Avec PIMMS, tu as une vision claire. Simple. Sans complexité. Et en digital, ç
         <PricingPlanFeatureList>
           <PricingPlanFeature>1 000 liens /mois</PricingPlanFeature>
           <PricingPlanFeature>10k événements suivis /mois</PricingPlanFeature>
-          <PricingPlanFeature>Suivi des ventes illimité</PricingPlanFeature>
           <PricingPlanFeature>5 domaines personnalisés</PricingPlanFeature>
           <PricingPlanFeature>Création de liens en masse</PricingPlanFeature>
           <PricingPlanFeature>12 mois de données</PricingPlanFeature>
@@ -351,7 +348,6 @@ Avec PIMMS, tu as une vision claire. Simple. Sans complexité. Et en digital, ç
         <PricingPlanFeatureList>
           <PricingPlanFeature>2 000 liens /mois</PricingPlanFeature>
           <PricingPlanFeature>20k événements suivis /mois</PricingPlanFeature>
-          <PricingPlanFeature>Suivi des ventes illimité</PricingPlanFeature>
           <PricingPlanFeature>10 membres d'équipe</PricingPlanFeature>
           <PricingPlanFeature>10 domaines personnalisés</PricingPlanFeature>
           <PricingPlanFeature>Création de liens en masse</PricingPlanFeature>
@@ -360,6 +356,8 @@ Avec PIMMS, tu as une vision claire. Simple. Sans complexité. Et en digital, ç
         </PricingPlanFeatureList>
       </PricingPlanPanel>
     </PricingHero>
+
+    <Text size="sm" className="text-center mt-4"><a href="/fr/pricing#compare" className="underline text-muted-foreground hover:text-foreground">Comparatif des plans</a></Text>
   </Section>
 </Slide>
 

--- a/content/fr/landings/pricing.mdx
+++ b/content/fr/landings/pricing.mdx
@@ -44,7 +44,7 @@ folder: ""
         <PricingPlanFeatureListTitle>Tout du Gratuit, plus :</PricingPlanFeatureListTitle>
         <PricingPlanFeatureList>
           <PricingPlanFeature>100 liens /mois</PricingPlanFeature>
-          <PricingPlanFeature>Jusqu'à 1 500 clics /mois</PricingPlanFeature>
+          <PricingPlanFeature>4 000 événements trackés /mois</PricingPlanFeature>
           <PricingPlanFeature>1 domaine personnalisé</PricingPlanFeature>
           <PricingPlanFeature>QR codes personnalisés</PricingPlanFeature>
           <PricingPlanFeature>1 an de données</PricingPlanFeature>
@@ -57,8 +57,6 @@ folder: ""
         <PricingPlanFeatureListTitle>Tout de Tiny, plus :</PricingPlanFeatureListTitle>
         <PricingPlanFeatureList>
           <PricingPlanFeature>500 liens /mois</PricingPlanFeature>
-          <PricingPlanFeature>Suivi des ventes illimité</PricingPlanFeature>
-          <PricingPlanFeature>Intégration paiements Stripe</PricingPlanFeature>
           <PricingPlanFeature>Tests A/B</PricingPlanFeature>
           <PricingPlanFeature>Webhooks &amp; API</PricingPlanFeature>
           <PricingPlanFeature>5 membres d'équipe</PricingPlanFeature>
@@ -73,7 +71,6 @@ folder: ""
         <PricingPlanFeatureList>
           <PricingPlanFeature>1 000 liens /mois</PricingPlanFeature>
           <PricingPlanFeature>10k événements suivis /mois</PricingPlanFeature>
-          <PricingPlanFeature>Suivi des ventes illimité</PricingPlanFeature>
           <PricingPlanFeature>5 domaines personnalisés</PricingPlanFeature>
           <PricingPlanFeature>Création de liens en masse</PricingPlanFeature>
           <PricingPlanFeature>12 mois de données</PricingPlanFeature>
@@ -87,7 +84,6 @@ folder: ""
         <PricingPlanFeatureList>
           <PricingPlanFeature>2 000 liens /mois</PricingPlanFeature>
           <PricingPlanFeature>20k événements suivis /mois</PricingPlanFeature>
-          <PricingPlanFeature>Suivi des ventes illimité</PricingPlanFeature>
           <PricingPlanFeature>10 membres d'équipe</PricingPlanFeature>
           <PricingPlanFeature>10 domaines personnalisés</PricingPlanFeature>
           <PricingPlanFeature>Création de liens en masse</PricingPlanFeature>
@@ -97,7 +93,9 @@ folder: ""
       </PricingPlanPanel>
     </PricingHero>
 
-    <H2>Comparer les plans en détail</H2>
+    <Text size="sm" className="text-center mt-4"><a href="#compare" className="underline text-muted-foreground hover:text-foreground">Comparatif des plans</a></Text>
+
+    <H2 id="compare">Comparer les plans en détail</H2>
     <CompareTable featuresHeader="Fonctionnalités" freeLabel="Gratuit" atATime="à la fois" unlimited="Illimité">
         <CompareCategory>Liens</CompareCategory>
         <CompareFeatureValue limitKey="links">Nouveaux liens/mois</CompareFeatureValue>

--- a/content/fr/landings/pricing.mdx
+++ b/content/fr/landings/pricing.mdx
@@ -44,7 +44,7 @@ folder: ""
         <PricingPlanFeatureListTitle>Tout du Gratuit, plus :</PricingPlanFeatureListTitle>
         <PricingPlanFeatureList>
           <PricingPlanFeature>100 liens /mois</PricingPlanFeature>
-          <PricingPlanFeature>4 000 événements trackés /mois</PricingPlanFeature>
+          <PricingPlanFeature>1 500 événements trackés /mois</PricingPlanFeature>
           <PricingPlanFeature>1 domaine personnalisé</PricingPlanFeature>
           <PricingPlanFeature>QR codes personnalisés</PricingPlanFeature>
           <PricingPlanFeature>1 an de données</PricingPlanFeature>

--- a/content/fr/landings/stripe.mdx
+++ b/content/fr/landings/stripe.mdx
@@ -348,7 +348,7 @@ Avec PIMMS, tu as une vision claire. Simple. Sans complexité. Et en digital, ç
         <PricingPlanFeatureListTitle>Tout du Gratuit, plus :</PricingPlanFeatureListTitle>
         <PricingPlanFeatureList>
           <PricingPlanFeature>100 liens /mois</PricingPlanFeature>
-          <PricingPlanFeature>Jusqu'à 1 500 clics /mois</PricingPlanFeature>
+          <PricingPlanFeature>4 000 événements trackés /mois</PricingPlanFeature>
           <PricingPlanFeature>1 domaine personnalisé</PricingPlanFeature>
           <PricingPlanFeature>QR codes personnalisés</PricingPlanFeature>
           <PricingPlanFeature>1 an de données</PricingPlanFeature>
@@ -361,8 +361,6 @@ Avec PIMMS, tu as une vision claire. Simple. Sans complexité. Et en digital, ç
         <PricingPlanFeatureListTitle>Tout de Tiny, plus :</PricingPlanFeatureListTitle>
         <PricingPlanFeatureList>
           <PricingPlanFeature>500 liens /mois</PricingPlanFeature>
-          <PricingPlanFeature>Suivi des ventes illimité</PricingPlanFeature>
-          <PricingPlanFeature>Intégration paiements Stripe</PricingPlanFeature>
           <PricingPlanFeature>Tests A/B</PricingPlanFeature>
           <PricingPlanFeature>Webhooks &amp; API</PricingPlanFeature>
           <PricingPlanFeature>5 membres d'équipe</PricingPlanFeature>
@@ -377,7 +375,6 @@ Avec PIMMS, tu as une vision claire. Simple. Sans complexité. Et en digital, ç
         <PricingPlanFeatureList>
           <PricingPlanFeature>1 000 liens /mois</PricingPlanFeature>
           <PricingPlanFeature>10k événements suivis /mois</PricingPlanFeature>
-          <PricingPlanFeature>Suivi des ventes illimité</PricingPlanFeature>
           <PricingPlanFeature>5 domaines personnalisés</PricingPlanFeature>
           <PricingPlanFeature>Création de liens en masse</PricingPlanFeature>
           <PricingPlanFeature>12 mois de données</PricingPlanFeature>
@@ -391,7 +388,6 @@ Avec PIMMS, tu as une vision claire. Simple. Sans complexité. Et en digital, ç
         <PricingPlanFeatureList>
           <PricingPlanFeature>2 000 liens /mois</PricingPlanFeature>
           <PricingPlanFeature>20k événements suivis /mois</PricingPlanFeature>
-          <PricingPlanFeature>Suivi des ventes illimité</PricingPlanFeature>
           <PricingPlanFeature>10 membres d'équipe</PricingPlanFeature>
           <PricingPlanFeature>10 domaines personnalisés</PricingPlanFeature>
           <PricingPlanFeature>Création de liens en masse</PricingPlanFeature>
@@ -400,6 +396,8 @@ Avec PIMMS, tu as une vision claire. Simple. Sans complexité. Et en digital, ç
         </PricingPlanFeatureList>
       </PricingPlanPanel>
     </PricingHero>
+
+    <Text size="sm" className="text-center mt-4"><a href="/fr/pricing#compare" className="underline text-muted-foreground hover:text-foreground">Comparatif des plans</a></Text>
   </Section>
 </Slide>
 

--- a/content/fr/landings/stripe.mdx
+++ b/content/fr/landings/stripe.mdx
@@ -348,7 +348,7 @@ Avec PIMMS, tu as une vision claire. Simple. Sans complexité. Et en digital, ç
         <PricingPlanFeatureListTitle>Tout du Gratuit, plus :</PricingPlanFeatureListTitle>
         <PricingPlanFeatureList>
           <PricingPlanFeature>100 liens /mois</PricingPlanFeature>
-          <PricingPlanFeature>4 000 événements trackés /mois</PricingPlanFeature>
+          <PricingPlanFeature>1 500 événements trackés /mois</PricingPlanFeature>
           <PricingPlanFeature>1 domaine personnalisé</PricingPlanFeature>
           <PricingPlanFeature>QR codes personnalisés</PricingPlanFeature>
           <PricingPlanFeature>1 an de données</PricingPlanFeature>

--- a/content/fr/landings/systemeio.mdx
+++ b/content/fr/landings/systemeio.mdx
@@ -348,7 +348,7 @@ Avec PIMMS, tu as une vision claire. Simple. Sans complexité. Et en digital, ç
         <PricingPlanFeatureListTitle>Tout du Gratuit, plus :</PricingPlanFeatureListTitle>
         <PricingPlanFeatureList>
           <PricingPlanFeature>100 liens /mois</PricingPlanFeature>
-          <PricingPlanFeature>Jusqu'à 1 500 clics /mois</PricingPlanFeature>
+          <PricingPlanFeature>4 000 événements trackés /mois</PricingPlanFeature>
           <PricingPlanFeature>1 domaine personnalisé</PricingPlanFeature>
           <PricingPlanFeature>QR codes personnalisés</PricingPlanFeature>
           <PricingPlanFeature>1 an de données</PricingPlanFeature>
@@ -361,8 +361,6 @@ Avec PIMMS, tu as une vision claire. Simple. Sans complexité. Et en digital, ç
         <PricingPlanFeatureListTitle>Tout de Tiny, plus :</PricingPlanFeatureListTitle>
         <PricingPlanFeatureList>
           <PricingPlanFeature>500 liens /mois</PricingPlanFeature>
-          <PricingPlanFeature>Suivi des ventes illimité</PricingPlanFeature>
-          <PricingPlanFeature>Intégration paiements Stripe</PricingPlanFeature>
           <PricingPlanFeature>Tests A/B</PricingPlanFeature>
           <PricingPlanFeature>Webhooks &amp; API</PricingPlanFeature>
           <PricingPlanFeature>5 membres d'équipe</PricingPlanFeature>
@@ -377,7 +375,6 @@ Avec PIMMS, tu as une vision claire. Simple. Sans complexité. Et en digital, ç
         <PricingPlanFeatureList>
           <PricingPlanFeature>1 000 liens /mois</PricingPlanFeature>
           <PricingPlanFeature>10k événements suivis /mois</PricingPlanFeature>
-          <PricingPlanFeature>Suivi des ventes illimité</PricingPlanFeature>
           <PricingPlanFeature>5 domaines personnalisés</PricingPlanFeature>
           <PricingPlanFeature>Création de liens en masse</PricingPlanFeature>
           <PricingPlanFeature>12 mois de données</PricingPlanFeature>
@@ -391,7 +388,6 @@ Avec PIMMS, tu as une vision claire. Simple. Sans complexité. Et en digital, ç
         <PricingPlanFeatureList>
           <PricingPlanFeature>2 000 liens /mois</PricingPlanFeature>
           <PricingPlanFeature>20k événements suivis /mois</PricingPlanFeature>
-          <PricingPlanFeature>Suivi des ventes illimité</PricingPlanFeature>
           <PricingPlanFeature>10 membres d'équipe</PricingPlanFeature>
           <PricingPlanFeature>10 domaines personnalisés</PricingPlanFeature>
           <PricingPlanFeature>Création de liens en masse</PricingPlanFeature>
@@ -400,6 +396,8 @@ Avec PIMMS, tu as une vision claire. Simple. Sans complexité. Et en digital, ç
         </PricingPlanFeatureList>
       </PricingPlanPanel>
     </PricingHero>
+
+    <Text size="sm" className="text-center mt-4"><a href="/fr/pricing#compare" className="underline text-muted-foreground hover:text-foreground">Comparatif des plans</a></Text>
   </Section>
 </Slide>
 

--- a/content/fr/landings/systemeio.mdx
+++ b/content/fr/landings/systemeio.mdx
@@ -348,7 +348,7 @@ Avec PIMMS, tu as une vision claire. Simple. Sans complexité. Et en digital, ç
         <PricingPlanFeatureListTitle>Tout du Gratuit, plus :</PricingPlanFeatureListTitle>
         <PricingPlanFeatureList>
           <PricingPlanFeature>100 liens /mois</PricingPlanFeature>
-          <PricingPlanFeature>4 000 événements trackés /mois</PricingPlanFeature>
+          <PricingPlanFeature>1 500 événements trackés /mois</PricingPlanFeature>
           <PricingPlanFeature>1 domaine personnalisé</PricingPlanFeature>
           <PricingPlanFeature>QR codes personnalisés</PricingPlanFeature>
           <PricingPlanFeature>1 an de données</PricingPlanFeature>

--- a/content/fr/landings/tally.mdx
+++ b/content/fr/landings/tally.mdx
@@ -348,7 +348,7 @@ Avec PIMMS, tu as une vision claire. Simple. Sans complexité. Et en digital, ç
         <PricingPlanFeatureListTitle>Tout du Gratuit, plus :</PricingPlanFeatureListTitle>
         <PricingPlanFeatureList>
           <PricingPlanFeature>100 liens /mois</PricingPlanFeature>
-          <PricingPlanFeature>Jusqu'à 1 500 clics /mois</PricingPlanFeature>
+          <PricingPlanFeature>4 000 événements trackés /mois</PricingPlanFeature>
           <PricingPlanFeature>1 domaine personnalisé</PricingPlanFeature>
           <PricingPlanFeature>QR codes personnalisés</PricingPlanFeature>
           <PricingPlanFeature>1 an de données</PricingPlanFeature>
@@ -361,8 +361,6 @@ Avec PIMMS, tu as une vision claire. Simple. Sans complexité. Et en digital, ç
         <PricingPlanFeatureListTitle>Tout de Tiny, plus :</PricingPlanFeatureListTitle>
         <PricingPlanFeatureList>
           <PricingPlanFeature>500 liens /mois</PricingPlanFeature>
-          <PricingPlanFeature>Suivi des ventes illimité</PricingPlanFeature>
-          <PricingPlanFeature>Intégration paiements Stripe</PricingPlanFeature>
           <PricingPlanFeature>Tests A/B</PricingPlanFeature>
           <PricingPlanFeature>Webhooks &amp; API</PricingPlanFeature>
           <PricingPlanFeature>5 membres d'équipe</PricingPlanFeature>
@@ -377,7 +375,6 @@ Avec PIMMS, tu as une vision claire. Simple. Sans complexité. Et en digital, ç
         <PricingPlanFeatureList>
           <PricingPlanFeature>1 000 liens /mois</PricingPlanFeature>
           <PricingPlanFeature>10k événements suivis /mois</PricingPlanFeature>
-          <PricingPlanFeature>Suivi des ventes illimité</PricingPlanFeature>
           <PricingPlanFeature>5 domaines personnalisés</PricingPlanFeature>
           <PricingPlanFeature>Création de liens en masse</PricingPlanFeature>
           <PricingPlanFeature>12 mois de données</PricingPlanFeature>
@@ -391,7 +388,6 @@ Avec PIMMS, tu as une vision claire. Simple. Sans complexité. Et en digital, ç
         <PricingPlanFeatureList>
           <PricingPlanFeature>2 000 liens /mois</PricingPlanFeature>
           <PricingPlanFeature>20k événements suivis /mois</PricingPlanFeature>
-          <PricingPlanFeature>Suivi des ventes illimité</PricingPlanFeature>
           <PricingPlanFeature>10 membres d'équipe</PricingPlanFeature>
           <PricingPlanFeature>10 domaines personnalisés</PricingPlanFeature>
           <PricingPlanFeature>Création de liens en masse</PricingPlanFeature>
@@ -400,6 +396,8 @@ Avec PIMMS, tu as une vision claire. Simple. Sans complexité. Et en digital, ç
         </PricingPlanFeatureList>
       </PricingPlanPanel>
     </PricingHero>
+
+    <Text size="sm" className="text-center mt-4"><a href="/fr/pricing#compare" className="underline text-muted-foreground hover:text-foreground">Comparatif des plans</a></Text>
   </Section>
 </Slide>
 

--- a/content/fr/landings/tally.mdx
+++ b/content/fr/landings/tally.mdx
@@ -348,7 +348,7 @@ Avec PIMMS, tu as une vision claire. Simple. Sans complexité. Et en digital, ç
         <PricingPlanFeatureListTitle>Tout du Gratuit, plus :</PricingPlanFeatureListTitle>
         <PricingPlanFeatureList>
           <PricingPlanFeature>100 liens /mois</PricingPlanFeature>
-          <PricingPlanFeature>4 000 événements trackés /mois</PricingPlanFeature>
+          <PricingPlanFeature>1 500 événements trackés /mois</PricingPlanFeature>
           <PricingPlanFeature>1 domaine personnalisé</PricingPlanFeature>
           <PricingPlanFeature>QR codes personnalisés</PricingPlanFeature>
           <PricingPlanFeature>1 an de données</PricingPlanFeature>

--- a/content/fr/landings/webflow.mdx
+++ b/content/fr/landings/webflow.mdx
@@ -348,7 +348,7 @@ Avec PIMMS, tu as une vision claire. Simple. Sans complexité. Et en digital, ç
         <PricingPlanFeatureListTitle>Tout du Gratuit, plus :</PricingPlanFeatureListTitle>
         <PricingPlanFeatureList>
           <PricingPlanFeature>100 liens /mois</PricingPlanFeature>
-          <PricingPlanFeature>Jusqu'à 1 500 clics /mois</PricingPlanFeature>
+          <PricingPlanFeature>4 000 événements trackés /mois</PricingPlanFeature>
           <PricingPlanFeature>1 domaine personnalisé</PricingPlanFeature>
           <PricingPlanFeature>QR codes personnalisés</PricingPlanFeature>
           <PricingPlanFeature>1 an de données</PricingPlanFeature>
@@ -361,8 +361,6 @@ Avec PIMMS, tu as une vision claire. Simple. Sans complexité. Et en digital, ç
         <PricingPlanFeatureListTitle>Tout de Tiny, plus :</PricingPlanFeatureListTitle>
         <PricingPlanFeatureList>
           <PricingPlanFeature>500 liens /mois</PricingPlanFeature>
-          <PricingPlanFeature>Suivi des ventes illimité</PricingPlanFeature>
-          <PricingPlanFeature>Intégration paiements Stripe</PricingPlanFeature>
           <PricingPlanFeature>Tests A/B</PricingPlanFeature>
           <PricingPlanFeature>Webhooks &amp; API</PricingPlanFeature>
           <PricingPlanFeature>5 membres d'équipe</PricingPlanFeature>
@@ -377,7 +375,6 @@ Avec PIMMS, tu as une vision claire. Simple. Sans complexité. Et en digital, ç
         <PricingPlanFeatureList>
           <PricingPlanFeature>1 000 liens /mois</PricingPlanFeature>
           <PricingPlanFeature>10k événements suivis /mois</PricingPlanFeature>
-          <PricingPlanFeature>Suivi des ventes illimité</PricingPlanFeature>
           <PricingPlanFeature>5 domaines personnalisés</PricingPlanFeature>
           <PricingPlanFeature>Création de liens en masse</PricingPlanFeature>
           <PricingPlanFeature>12 mois de données</PricingPlanFeature>
@@ -391,7 +388,6 @@ Avec PIMMS, tu as une vision claire. Simple. Sans complexité. Et en digital, ç
         <PricingPlanFeatureList>
           <PricingPlanFeature>2 000 liens /mois</PricingPlanFeature>
           <PricingPlanFeature>20k événements suivis /mois</PricingPlanFeature>
-          <PricingPlanFeature>Suivi des ventes illimité</PricingPlanFeature>
           <PricingPlanFeature>10 membres d'équipe</PricingPlanFeature>
           <PricingPlanFeature>10 domaines personnalisés</PricingPlanFeature>
           <PricingPlanFeature>Création de liens en masse</PricingPlanFeature>
@@ -400,6 +396,8 @@ Avec PIMMS, tu as une vision claire. Simple. Sans complexité. Et en digital, ç
         </PricingPlanFeatureList>
       </PricingPlanPanel>
     </PricingHero>
+
+    <Text size="sm" className="text-center mt-4"><a href="/fr/pricing#compare" className="underline text-muted-foreground hover:text-foreground">Comparatif des plans</a></Text>
   </Section>
 </Slide>
 

--- a/content/fr/landings/webflow.mdx
+++ b/content/fr/landings/webflow.mdx
@@ -348,7 +348,7 @@ Avec PIMMS, tu as une vision claire. Simple. Sans complexité. Et en digital, ç
         <PricingPlanFeatureListTitle>Tout du Gratuit, plus :</PricingPlanFeatureListTitle>
         <PricingPlanFeatureList>
           <PricingPlanFeature>100 liens /mois</PricingPlanFeature>
-          <PricingPlanFeature>4 000 événements trackés /mois</PricingPlanFeature>
+          <PricingPlanFeature>1 500 événements trackés /mois</PricingPlanFeature>
           <PricingPlanFeature>1 domaine personnalisé</PricingPlanFeature>
           <PricingPlanFeature>QR codes personnalisés</PricingPlanFeature>
           <PricingPlanFeature>1 an de données</PricingPlanFeature>

--- a/content/fr/landings/youtube.mdx
+++ b/content/fr/landings/youtube.mdx
@@ -305,7 +305,7 @@ Et quand je mets en ligne une nouvelle page, si le visiteur est identifié dans 
         <PricingPlanFeatureListTitle>Tout du Gratuit, plus :</PricingPlanFeatureListTitle>
         <PricingPlanFeatureList>
           <PricingPlanFeature>100 liens /mois</PricingPlanFeature>
-          <PricingPlanFeature>Jusqu'à 1 500 clics /mois</PricingPlanFeature>
+          <PricingPlanFeature>4 000 événements trackés /mois</PricingPlanFeature>
           <PricingPlanFeature>1 domaine personnalisé</PricingPlanFeature>
           <PricingPlanFeature>QR codes personnalisés</PricingPlanFeature>
           <PricingPlanFeature>1 an de données</PricingPlanFeature>
@@ -318,8 +318,6 @@ Et quand je mets en ligne une nouvelle page, si le visiteur est identifié dans 
         <PricingPlanFeatureListTitle>Tout de Tiny, plus :</PricingPlanFeatureListTitle>
         <PricingPlanFeatureList>
           <PricingPlanFeature>500 liens /mois</PricingPlanFeature>
-          <PricingPlanFeature>Suivi des ventes illimité</PricingPlanFeature>
-          <PricingPlanFeature>Intégration paiements Stripe</PricingPlanFeature>
           <PricingPlanFeature>Tests A/B</PricingPlanFeature>
           <PricingPlanFeature>Webhooks &amp; API</PricingPlanFeature>
           <PricingPlanFeature>5 membres d'équipe</PricingPlanFeature>
@@ -334,7 +332,6 @@ Et quand je mets en ligne une nouvelle page, si le visiteur est identifié dans 
         <PricingPlanFeatureList>
           <PricingPlanFeature>1 000 liens /mois</PricingPlanFeature>
           <PricingPlanFeature>10k événements suivis /mois</PricingPlanFeature>
-          <PricingPlanFeature>Suivi des ventes illimité</PricingPlanFeature>
           <PricingPlanFeature>5 domaines personnalisés</PricingPlanFeature>
           <PricingPlanFeature>Création de liens en masse</PricingPlanFeature>
           <PricingPlanFeature>12 mois de données</PricingPlanFeature>
@@ -348,7 +345,6 @@ Et quand je mets en ligne une nouvelle page, si le visiteur est identifié dans 
         <PricingPlanFeatureList>
           <PricingPlanFeature>2 000 liens /mois</PricingPlanFeature>
           <PricingPlanFeature>20k événements suivis /mois</PricingPlanFeature>
-          <PricingPlanFeature>Suivi des ventes illimité</PricingPlanFeature>
           <PricingPlanFeature>10 membres d'équipe</PricingPlanFeature>
           <PricingPlanFeature>10 domaines personnalisés</PricingPlanFeature>
           <PricingPlanFeature>Création de liens en masse</PricingPlanFeature>
@@ -357,6 +353,8 @@ Et quand je mets en ligne une nouvelle page, si le visiteur est identifié dans 
         </PricingPlanFeatureList>
       </PricingPlanPanel>
     </PricingHero>
+
+    <Text size="sm" className="text-center mt-4"><a href="/fr/pricing#compare" className="underline text-muted-foreground hover:text-foreground">Comparatif des plans</a></Text>
   </Section>
 </Slide>
 

--- a/content/fr/landings/youtube.mdx
+++ b/content/fr/landings/youtube.mdx
@@ -305,7 +305,7 @@ Et quand je mets en ligne une nouvelle page, si le visiteur est identifié dans 
         <PricingPlanFeatureListTitle>Tout du Gratuit, plus :</PricingPlanFeatureListTitle>
         <PricingPlanFeatureList>
           <PricingPlanFeature>100 liens /mois</PricingPlanFeature>
-          <PricingPlanFeature>4 000 événements trackés /mois</PricingPlanFeature>
+          <PricingPlanFeature>1 500 événements trackés /mois</PricingPlanFeature>
           <PricingPlanFeature>1 domaine personnalisé</PricingPlanFeature>
           <PricingPlanFeature>QR codes personnalisés</PricingPlanFeature>
           <PricingPlanFeature>1 an de données</PricingPlanFeature>

--- a/lib/pricing.ts
+++ b/lib/pricing.ts
@@ -93,7 +93,7 @@ export const PLANS: Plan[] = [
     },
     limits: {
       links: 100,
-      clicks: 1_500,
+      clicks: 4_000,
       sales: INFINITY_NUMBER,
       domains: 1,
       tags: 25,
@@ -109,7 +109,7 @@ export const PLANS: Plan[] = [
     featureTitle: "Everything in Free, plus:",
     features: [
       { id: "links", text: "100 links /month" },
-      { id: "clicks", text: "Up to 1,500 clicks /month" },
+      { id: "clicks", text: "4,000 events tracked /month" },
       { id: "domain", text: "1 custom domain" },
       { id: "qr", text: "Custom QR codes" },
       { id: "retention", text: "1 year of data" },
@@ -151,8 +151,6 @@ export const PLANS: Plan[] = [
     featureTitle: "Everything in Tiny, plus:",
     features: [
       { id: "links", text: "500 links /month" },
-      { id: "sales", text: "Unlimited sales tracking" },
-      { id: "stripe", text: "Stripe payments integration" },
       { id: "testing", text: "A/B testing" },
       { id: "webhooks", text: "Webhooks & API" },
       { id: "users", text: "5 team members" },
@@ -194,7 +192,6 @@ export const PLANS: Plan[] = [
     features: [
       { id: "links", text: "1,000 links /month" },
       { id: "tracking", text: "10k events tracked /month" },
-      { id: "sales", text: "Unlimited sales tracking" },
       { id: "domains", text: "5 custom domains" },
       { id: "bulk", text: "Bulk link operations" },
       { id: "retention", text: "12 months of data" },
@@ -237,7 +234,6 @@ export const PLANS: Plan[] = [
     features: [
       { id: "links", text: "2,000 links /month" },
       { id: "tracking", text: "20k events tracked /month" },
-      { id: "sales", text: "Unlimited sales tracking" },
       { id: "users", text: "10 team members" },
       { id: "domains", text: "10 custom domains" },
       { id: "bulk", text: "Bulk link operations" },

--- a/lib/pricing.ts
+++ b/lib/pricing.ts
@@ -93,7 +93,7 @@ export const PLANS: Plan[] = [
     },
     limits: {
       links: 100,
-      clicks: 4_000,
+      clicks: 1_500,
       sales: INFINITY_NUMBER,
       domains: 1,
       tags: 25,
@@ -109,7 +109,7 @@ export const PLANS: Plan[] = [
     featureTitle: "Everything in Free, plus:",
     features: [
       { id: "links", text: "100 links /month" },
-      { id: "clicks", text: "4,000 events tracked /month" },
+      { id: "clicks", text: "1,500 events tracked /month" },
       { id: "domain", text: "1 custom domain" },
       { id: "qr", text: "Custom QR codes" },
       { id: "retention", text: "1 year of data" },


### PR DESCRIPTION
## Changes

### 1. Tiny plan: 4,000 events/month
- clicks limit: 1,500 → 4,000
- Feature text updated in all 32 MDX files (EN + FR)

### 2. Remove redundant features
- Unlimited sales tracking removed from Solo/Pro/Business (all plans have it)
- Stripe payments integration removed from Solo (all plans have it)

### 3. Mobile compare link
- Added Compare plans link after pricing cards in all pages
- Links to #compare on pricing page

### Note
Solo plan has clicks: 3,000 which is now less than Tiny 4,000. May need adjustment.