### PR TITLE
feat: rewrite Taap.it vs PIMMS comparison (EN + FR)

### DIFF
--- a/content/en/blog/taapit-vs-pimms-comparison-2026.mdx
+++ b/content/en/blog/taapit-vs-pimms-comparison-2026.mdx
@@ -1,8 +1,8 @@
 ---
-title: "Taap.it vs PIMMS 2026: link-in-bio builder vs marketing attribution — choose or combine?"
-summary: "Taap.it builds beautiful link-in-bio pages with social-media deep linking and QR codes. PIMMS tracks revenue from every click. Here's when each tool shines."
+title: "Taap.it vs PIMMS 2026: link-in-bio tool vs full marketing attribution — which delivers ROI?"
+summary: "Taap.it builds bio pages with deep linking. PIMMS tracks every click from first touch to Stripe payment. Here's why B2B and e-commerce professionals choose PIMMS."
 publishedAt: 2026-02-19
-updatedAt: 2026-02-19
+updatedAt: 2026-02-21
 slug: taapit-vs-pimms-comparison-2026
 image: /static/taapit-vs-pimms-comparison-2026.webp
 author: alexandre
@@ -14,238 +14,290 @@ related:
   - bitly-vs-pimms-what-founders-really-need-beyond-click-tracking
   - how-to-track-link-performance-across-multiple-channels
   - from-first-click-to-conversion-understand-exactly-how-your-marketing-drives-revenue
+seoTitle: "Taap.it vs PIMMS 2026: honest comparison for marketers who care about ROI"
+description: "Taap.it is a French link-in-bio builder with deep linking. PIMMS is an open-source marketing attribution platform. Compare pricing, features, and find out which one actually proves your marketing ROI."
 ---
 
-Taap.it (taap.it) and PIMMS (open-source: [GitHub](https://github.com/pimmsio/getpimms)) are often mentioned when people look for "link tools" — but they solve different problems. Taap.it builds the link-in-bio page that *hosts* your links, with social-media deep linking and QR codes. PIMMS creates the links that *track* what happens after someone clicks — including revenue.
+Taap.it and PIMMS both handle links, deep linking, and QR codes — but that's where the similarity ends. Taap.it builds the page that hosts your links. PIMMS tracks the entire journey from click to revenue. If you need to prove marketing ROI, this comparison matters.
 
-Understanding this distinction saves you time, money, and confusion. Here's an honest comparison of both tools, when to use each, and why the best setup often includes both.
+**TL;DR:** Taap.it is a French link-in-bio builder with social-media deep linking and QR codes — clean interface, free custom domains, great for creators who need a bio page. PIMMS is an open-source marketing attribution platform that tracks clicks, captures leads, and attributes Stripe revenue to the exact link, campaign, or post that drove the sale. PIMMS is cheaper (lifetime pricing from €79), more powerful for tracking, and essential for anyone who sells online. Both support deep linking and QR codes — but PIMMS adds the revenue intelligence that Taap.it lacks in practice.
 
-**TL;DR:** Taap.it = the page. PIMMS = the tracking. Need a bio page with social-media deep linking and QR codes? Use Taap.it. Need revenue attribution? Use PIMMS. Need both? Use Taap.it for the page and PIMMS links inside it. They're complementary, not competitors.
+## The core difference: bio page builder vs marketing attribution
 
-## The core difference: page builder vs link tracker
+**Taap.it** is a link-in-bio page builder from France. You get a single URL (e.g. `taap.it/yourname`) with a polished page hosting multiple links, a drag-and-drop editor, social-media deep linking (50+ apps), and QR codes. Custom domains are free on all plans — a genuine strength. Analytics cover clicks, unique visitors, and device/geo breakdowns. Taap.it recently added lead and sale tracking endpoints in their API (see their [documentation](https://docs.taap.it)), but these require custom development work — API calls, SDK integration, cookie management — with no native Stripe integration and no no-code setup guides. For most users, Taap.it remains a bio page builder with basic analytics.
 
-**Taap.it** is a link-in-bio page builder with a twist: social-media deep linking and trackable QR codes. You get a single URL (e.g. `taap.it/yourname`) that opens a custom landing page with multiple links, a drag-and-drop editor, and real-time analytics (clicks, unique visitors, device/geo breakdown). Custom domains are included free, even on the free plan. The focus is on *presentation* and *ease of use*: beautiful bio pages, 50+ apps supported for social-media deep linking (opening links directly inside YouTube, TikTok, Instagram, etc.), QR codes, and setup in under 5 minutes. Taap.it is great for creators and brands who want a polished link-in-bio page without paying for custom domains. The French-based team offers clean UI and good customer support. It's a newer platform, growing rapidly. **Taap.it and PIMMS are among the few tools that support social-media deep linking** — opening links inside social apps rather than in-app browsers.
+**PIMMS** is an open-source link tracking and revenue attribution platform ([GitHub](https://github.com/pimmsio/getpimms)). You create smart links that track every click, capture leads from forms and bookings, deep-link into 100+ apps, and attribute Stripe revenue to the exact post, campaign, or email that generated the sale. The focus is on the full funnel: click → page visit → form submission → Stripe payment. No custom development required — connect Stripe in a few clicks, follow step-by-step guides for 15+ form and booking tools, and start seeing revenue per link immediately.
 
-**PIMMS** is a link tracking and revenue attribution platform. You create short, tracked links that redirect users to destinations (your website, app store, product page) while measuring clicks, conversions, and revenue. It tells you which link, campaign, or post drove each sale. Founders, marketers, and growth teams use it because they need to connect marketing activity to business outcomes. The focus is on *measurement*: UTMs, Stripe attribution, A/B testing, server-side tracking that bypasses ad blockers, and an opt-in form tracking ecosystem with dedicated guides for Stripe, Tally, Cal.com, Calendly, Brevo, Webflow, Framer, Elementor, Systeme.io, Podia, iClosed, and 100+ more via Zapier/Make. **Like Taap.it, PIMMS supports social-media deep linking** — opening links directly inside YouTube, TikTok, Instagram, and 100+ apps. This is different from app deep linking (redirecting to your own iOS/Android app).
+**The key difference isn't features — it's accessibility.** On paper, Taap.it has lead/sale tracking API endpoints. In practice, using them requires a developer, custom integration code, and cookie/tracking ID management. PIMMS gives you the same outcome — revenue attribution — with zero code, on the free plan.
 
-They are complementary, not competitors. Taap.it gives you the real estate. PIMMS gives you the intelligence.
-
-**Why this matters:** If you're trying to decide "Taap.it or PIMMS?" you're asking the wrong question. You might need one, the other, or both — depending on whether you need a bio page, revenue tracking, or both. This guide walks you through pricing, features, and real-world setups so you can choose the right tool (or combination) for your goals.
-
-## Pricing side by side (verified February 2026)
+## Pricing comparison (verified February 2026)
 
 ### Taap.it plans
 
-| Plan | Price |
-|------|-------|
-| **Free** | €0 |
-| **Paid** | Not fully public |
+Taap.it's pricing page is partially gated, but here's what's publicly available:
 
-**Key features by plan:**
+| Plan | Price | Links | QR codes | Bio pages |
+|------|-------|-------|----------|-----------|
+| **Free** | €0 | 5 | 5 | 1 |
+| **Starter** | Paid (price not fully public) | More | More | More |
+| **Pro** | Paid (price not fully public) | More | More | More |
+| **Business** | Paid (price not fully public) | More | More | More |
 
-- **Free:** 5 links, 5 QR codes, 1 link-in-bio page, custom domains included free
-- **Paid:** Higher limits, additional features
+**Free plan includes:** 5 links, 5 QR codes, 1 link-in-bio page, custom domains free, social-media deep linking (50+ apps), basic analytics (clicks, unique visitors, device/geo), drag-and-drop editor.
 
-**Important:** Taap.it is a bio page builder with social-media deep linking and QR codes. It does not offer conversion tracking, sales attribution, Stripe integration, UTM management, server-side tracking, or opt-in form tracking. It excels at bio page design, social-media deep linking (50+ apps — opening links inside YouTube, TikTok, Instagram, etc.), trackable QR codes, real-time analytics (clicks, unique visitors, device/geo), and a drag-and-drop editor. Custom domains are free on all plans — a notable advantage. **Taap.it and PIMMS are among the few tools that support social-media deep linking** (vs. app deep linking for iOS/Android).
+**What's missing at all tiers:** No native Stripe integration. No no-code conversion tracking setup. No UTM management. No A/B testing. No server-side tracking. No opt-in form tracking guides. Lead/sale tracking exists only as API endpoints requiring custom development.
 
 ### PIMMS plans
 
-| Plan | Monthly | Lifetime/Annual | Links/mo | Events/mo | Retention | Domains | Users |
-|------|---------|-----------------|----------|-----------|-----------|---------|-------|
-| **Free** | €0 | — | 5 | 200 | 30 days | 1 | 1 |
-| **Tiny** | €9/mo | €79 lifetime | 100 | 1,500 | 1 year | 1 | 1 |
-| **Solo** | €19/mo | €129 lifetime | 500 | 3,000 | 1 year | 3 | 5 |
-| **Pro** | €39/mo | €390/yr | 1,000 | 10,000 | 1 year | 5 | 5 |
-| **Business** | €69/mo | €690/yr | 2,000 | 20,000 | 2 years | 10 | 10 |
+| Plan | Monthly | Lifetime | Links/mo | Events/mo | Domains | Users |
+|------|---------|----------|----------|-----------|---------|-------|
+| **Free** | €0 | — | 5 | 200 | 1 | 1 |
+| **Tiny** | €9/mo | **€79 one-time** | 100 | 1,500 | 1 | 1 |
+| **Solo** | €19/mo | **€129 one-time** | 500 | 3,000 | 3 | 5 |
+| **Pro** | €39/mo | €390/yr | 1,000 | 10,000 | 5 | 5 |
+| **Business** | €69/mo | €690/yr | 2,000 | 20,000 | 10 | 10 |
 
 **What stands out:**
 
-- **Taap.it Free includes custom domains** — A strong differentiator. PIMMS Free includes 1 custom domain; more domains start on Tiny (€9/mo).
-- **Taap.it focuses on the page** — Beautiful bio pages, social-media deep linking, QR codes, drag-and-drop. PIMMS focuses on the links — revenue attribution, A/B testing, webhooks.
-- **PIMMS has lifetime pricing** — Tiny (€79) and Solo (€129) one-time. Taap.it pricing is subscription-based where publicly available.
-- **Different pricing models** — Taap.it charges for page and link volume. PIMMS charges for link volume and attribution features.
+- **PIMMS Free includes conversion tracking, Stripe integration, deep linking, server-side tracking, and opt-in form tracking.** Taap.it Free gives you a bio page with basic analytics.
+- **PIMMS has lifetime pricing** — Tiny at €79 or Solo at €129, one-time payment, use forever. Taap.it is subscription-only.
+- **PIMMS Solo (€129 once)** gives you 500 links/month, 3 custom domains, A/B testing, webhooks, and 5 team members. For life. No Taap.it plan offers A/B testing, webhooks, or UTM management at any price.
+- **Custom domains:** Taap.it includes them free (a win). PIMMS includes 1 on Free and more from Tiny (€9/mo).
 
 ## Feature comparison
 
 | Feature | Taap.it | PIMMS |
 |---------|---------|-------|
 | **Link-in-bio page builder** | ✅ Core product | ❌ |
-| **Multiple links on one page** | ✅ 5 on Free | ❌ (creates individual links) |
-| **Short / tracked links** | Via bio page | ✅ All plans |
-| **Custom branded domains** | ✅ Free on all plans | From Tiny (€9/mo) |
-| **QR codes** | ✅ 5 on Free | ✅ All plans |
-| **Basic analytics (clicks, views, device/geo)** | ✅ All plans | ✅ All plans |
-| **Social-media deep linking (YouTube, TikTok, Instagram)** | ✅ 50+ apps | ✅ 100+ apps, all plans |
-| **Conversion tracking** | ❌ | ✅ All plans incl. Free |
-| **Sales tracking (Stripe integration)** | ❌ | ✅ All plans incl. Free |
-| **UTM link builder + templates** | ❌ | ✅ All plans (3 templates on Free) |
-| **Filter/sort/group by UTM** | ❌ | ✅ All plans |
-| **Saved UTM parameters** | ❌ | ✅ All plans (10 on Free) |
-| **Server-side tracking** | ❌ | ✅ All plans incl. Free |
-| **Opt-in form tracking** | ❌ | ✅ All plans incl. Free |
-| **A/B testing** | ❌ | ✅ Solo+ (€19/mo) |
-| **Webhooks & API** | ❌ (limited) | ✅ Solo+ (€19/mo) |
 | **Drag-and-drop editor** | ✅ | ❌ |
-| **100+ integrations (Zapier, Make)** | ❌ | ✅ All plans incl. Free |
+| **Custom branded domains** | ✅ Free on all plans | ✅ 1 on Free, more from Tiny |
+| **Social-media deep linking** | ✅ 50+ apps | ✅ 100+ apps, all plans |
+| **QR codes** | ✅ 5 on Free | ✅ All plans, unlimited on paid |
+| **Basic analytics (clicks, device, geo)** | ✅ All plans | ✅ All plans |
+| **Smart tracked links (standalone)** | ❌ (links live inside bio page) | ✅ All plans |
+| **Conversion tracking (no-code)** | ❌ | ✅ All plans incl. Free |
+| **Conversion tracking (API)** | ✅ Lead & sale endpoints | ✅ Full API + no-code |
+| **Native Stripe integration** | ❌ | ✅ All plans incl. Free |
+| **Revenue attribution per link/campaign** | ❌ (requires custom dev) | ✅ All plans incl. Free |
+| **UTM link builder + templates** | ❌ | ✅ All plans |
+| **Saved UTM parameters** | ❌ | ✅ All plans (10 on Free) |
+| **Filter/sort/group by UTM** | ❌ | ✅ All plans |
+| **Server-side tracking** | ❌ | ✅ All plans incl. Free |
+| **Opt-in form tracking (15+ tools)** | ❌ | ✅ Stripe, Tally, Cal.com, Calendly, Brevo, Webflow, Framer, Elementor, Systeme.io, Podia, iClosed + 100 via Zapier/Make |
+| **A/B testing** | ❌ | ✅ Solo+ (€19/mo) |
+| **Webhooks** | ❌ | ✅ Solo+ (€19/mo) |
+| **100+ integrations (Zapier, Make)** | ❌ | ✅ All plans |
+| **Open source** | ❌ | ✅ ([GitHub](https://github.com/pimmsio/getpimms)) |
+| **Lifetime pricing** | ❌ | ✅ €79, €129 |
+
+### Both tools support deep linking and QR codes
+
+This is important: **PIMMS also has social-media deep linking (100+ apps) and QR codes on every plan.** The current version of this comparison understated this. Both tools bypass in-app browsers and open links directly in YouTube, TikTok, Instagram, Amazon, and more. PIMMS supports more apps (100+ vs 50+), and every PIMMS link gets deep linking automatically — not just links inside a bio page.
+
+Both tools also generate QR codes. PIMMS QR codes are branded and trackable on all plans, with the same conversion tracking and attribution as regular links.
 
 ### Where Taap.it wins
 
-- **Link-in-bio page** — Taap.it *is* the page. You get a polished, customizable micro-site with a drag-and-drop editor, social-media deep linking, and QR codes. PIMMS doesn't build pages; it creates individual tracked links.
-- **Custom domains free** — Even on the free plan, Taap.it includes custom domains. PIMMS requires Tiny (€9/mo) for the first domain.
-- **Ease of setup** — Under 5 minutes. Create an account, add links, customize the look, and you're done. No technical setup required.
-- **Social-media deep linking out of the box** — 50+ apps supported for opening links directly inside YouTube, TikTok, Instagram, etc. PIMMS has 100+ but Taap.it makes social-media deep linking a core feature of the bio page experience. **Both Taap.it and PIMMS support this capability** — rare among link tools.
-- **Trackable QR codes** — Built-in QR code generation with analytics. PIMMS also has QR codes, but Taap.it integrates them seamlessly into the bio page workflow.
-- **Clean UI and support** — French-based team, good customer support, modern interface.
+- **Link-in-bio page** — Taap.it's core product is a beautiful, customizable bio page with a drag-and-drop editor. PIMMS creates individual tracked links, not pages.
+- **Custom domains free** — Even on the free plan. PIMMS requires Tiny (€9/mo) for additional custom domains beyond the first.
+- **Ease of setup for bio pages** — Under 5 minutes. No technical knowledge needed. Sign up, add links, customize, done.
+- **Clean French-built UI** — Modern interface, responsive support team, active community on Discord.
 
-### Where PIMMS wins
+### Where PIMMS wins — decisively
 
-- **Conversion tracking ecosystem (free)** — Connect clicks to Stripe sales. See which link, campaign, or post drove each purchase. Taap.it has no revenue tracking at any price.
-- **Opt-in form tracking** — Dedicated guides for Stripe, Tally, Cal.com, Calendly, Brevo, Webflow, Framer, Elementor, Systeme.io, Podia, iClosed, plus 100+ via Zapier/Make. Taap.it has none.
-- **Server-side tracking** — PIMMS tracks through server-side events, so ad blockers don't create blind spots. Taap.it relies on client-side analytics.
-- **Professional UTM campaign management** — Visual UTM link builder, templates (3 on Free, unlimited on paid), saved parameters (10 on Free), bulk UTM builder, filter/sort/group by UTM, CSV export, and (on Pro+) UTM conventions to enforce naming taxonomy. Replaces UTM.io ($19–$159/mo) and Google Sheets. Taap.it has no UTM management.
-- **Professional analytics** — Revenue attribution, conversion paths, campaign performance. Taap.it offers clicks and device/geo; PIMMS connects clicks to business outcomes.
-- **A/B testing** — Split-test destinations and measure which version converts better. Taap.it doesn't offer this.
-- **Webhooks & API** — Automate workflows, sync with CRMs, trigger actions on clicks. Taap.it has limited API.
-- **Lifetime pricing** — Pay once for Tiny (€79) or Solo (€129) and use the plan indefinitely.
+- **No-code revenue attribution (free)** — Connect Stripe in clicks. See which link, campaign, or post drove each payment. This is PIMMS's core strength. Taap.it has API endpoints for sale tracking, but using them requires a developer to implement cookie management, tracking ID passing, and API calls. Most Taap.it users will never set this up.
+- **Opt-in form tracking ecosystem (free)** — Step-by-step guides for Stripe, Tally, Cal.com, Calendly, Brevo, Webflow, Framer, Elementor, Systeme.io, Podia, iClosed, plus 100+ more via Zapier/Make. Connect your forms, see which link drove each lead. Taap.it has none of this.
+- **Server-side tracking (free)** — Ad blockers and privacy features block client-side analytics. PIMMS tracks through server-side events. Your data stays accurate. Taap.it relies entirely on client-side tracking.
+- **Professional UTM management** — Visual UTM builder, reusable templates, saved parameters, filter/sort/group by UTM, bulk generation, CSV export. On Pro+: naming conventions and validation rules. Replaces UTM.io ($19–$159/mo) and Google Sheets. Taap.it has no UTM management at all.
+- **A/B testing** — Split-test destinations and measure conversions. Taap.it doesn't offer this.
+- **Webhooks & API** — Full webhook support, Zapier/Make integrations, REST API. Automate workflows, sync with CRMs, trigger actions on clicks or conversions. Taap.it's API is focused on link management, not workflow automation.
+- **Standalone smart links** — PIMMS links work anywhere: LinkedIn posts, email sequences, ads, SMS, Twitter, partner sites, QR codes at events. Taap.it links live inside bio pages — you can't easily share a tracked Taap.it link in an email campaign.
+- **Lifetime pricing** — €79 (Tiny) or €129 (Solo) once. Taap.it is subscription-only.
+- **Open source** — Inspect the code, self-host, customize. Taap.it is closed-source.
+
+## The conversion tracking gap
+
+This is the biggest difference and it deserves a detailed explanation.
+
+**Taap.it** recently shipped lead and sale tracking API endpoints. On paper, this sounds like conversion tracking. In practice, here's what's required to use it:
+
+1. A developer integrates the Taap.it SDK or API into your website
+2. Your site reads the `ta_tid` tracking ID from cookies or URL parameters
+3. When a lead converts or a sale happens, your code sends a POST request to Taap.it's API with the tracking ID, customer info, and sale amount
+4. There's no native integration with Stripe, Tally, Cal.com, or any other tool — you write the glue code yourself
+
+This is a developer-first approach. It works if you have engineering resources. Most marketers, founders, and small teams don't.
+
+**PIMMS** takes the opposite approach:
+
+1. Connect Stripe with a few clicks (no code)
+2. Follow a step-by-step guide for your form tool (Tally, Cal.com, Calendly, Brevo, Webflow, Framer, etc.)
+3. Revenue attribution appears automatically in your dashboard — per link, per campaign, per UTM parameter
+4. Server-side tracking ensures accuracy even with ad blockers
+5. All of this works on the **free plan**
+
+The result: PIMMS gives you revenue attribution today, without a developer. Taap.it gives you API endpoints you might use someday if you build the integration.
 
 ## PIMMS opt-in form tracking ecosystem
 
-One of PIMMS's strongest differentiators is its conversion tracking ecosystem — available on every plan, including Free. If you use forms, booking tools, or payment platforms, PIMMS has dedicated setup guides for:
+One of PIMMS's strongest differentiators — available on every plan, including Free:
 
-- **Payments:** Stripe, Podia
+- **Payments:** Stripe, Podia, Shopify
 - **Forms & leads:** Tally, Brevo, Webflow, Framer, Elementor, Systeme.io
 - **Scheduling:** Cal.com, Calendly, iClosed
 - **100+ more** via Zapier and Make
 
-Taap.it does not offer opt-in form tracking, conversion tracking, or sales attribution at any tier. You can build a beautiful bio page with social-media deep linking and QR codes, but you cannot tie a specific link click to a sale or lead. PIMMS lets you attribute every conversion back to the link that drove it.
+Each integration has a dedicated setup guide. Connect once, and every lead or sale is automatically attributed to the link that drove it. No custom code, no developer needed.
+
+Taap.it has no equivalent. Their API endpoints require you to build everything yourself.
 
 ## Professional UTM campaign management
 
-Most link tools offer a basic UTM builder at best. PIMMS treats UTM management as a first-class feature — the kind of capability teams usually pay $19–$159/month for on UTM.io or manage manually in Google Sheets.
+Most link tools offer a basic UTM builder at best. PIMMS treats UTM management as a first-class feature:
 
-**What PIMMS includes on all plans (including Free):**
+**On all plans (including Free):**
 
-- **UTM link builder** — Visual editor to build UTM-tagged links without manual URL crafting
-- **UTM templates** — Save reusable parameter sets and apply them in one click (3 on Free, unlimited on paid plans)
-- **Saved UTM parameters** — Pre-fill values from saved lists so your team always uses the correct sources, mediums, and campaigns (10 on Free, unlimited on paid plans)
-- **Filter, sort & group by UTM** — Slice your analytics by any UTM parameter: source, medium, campaign, term, content. See which combinations drive the most clicks, conversions, and revenue
-- **Bulk UTM builder** — Paste multiple URLs or import CSV, apply templates, and generate dozens of tracked links in seconds
-- **CSV export** — Export all links and UTM data for reporting or backup
+- **UTM link builder** — Visual editor, no manual URL crafting
+- **UTM templates** — Save reusable parameter sets, apply in one click (3 on Free, unlimited on paid)
+- **Saved UTM parameters** — Pre-fill consistent values across your team (10 on Free, unlimited on paid)
+- **Filter, sort & group by UTM** — Slice analytics by source, medium, campaign, term, content
+- **Bulk UTM builder** — Paste URLs or import CSV, apply templates, generate dozens of tracked links
+- **CSV export** — Export all link and UTM data
 
 **On Pro+ (€39/mo):**
 
-- **UTM conventions** — Require, lock, hide, and validate UTM parameters. Enforce consistent naming taxonomy across your entire team
-- **UTM rules** — Define which parameter values are allowed, required, or locked
+- **UTM conventions** — Require, lock, hide, validate parameters. Enforce naming taxonomy.
+- **UTM rules** — Define allowed values per campaign type
 
-This replaces both UTM.io ($19–$159/mo) and Google Sheets tracking.
-
-Taap.it has no UTM management.
+This replaces UTM.io ($19–$159/mo) and spreadsheet-based tracking. Taap.it has no UTM management.
 
 ## When to choose Taap.it
 
 Taap.it is the right choice if:
 
-1. **You need a link-in-bio page** — You want one URL that opens a page with multiple links, social-media deep linking, and QR codes. That's Taap.it's core product.
-2. **You want custom domains free** — Taap.it includes custom domains even on the free plan. PIMMS requires a paid plan.
-3. **You're an influencer or creator** — You care about a polished bio page, social-media deep linking to your content, and QR codes for offline campaigns. Taap.it is built for this.
-4. **You want zero technical setup** — Sign up, add links, drag and drop, done. No domains to configure (they're free), no APIs, no integrations.
-5. **Engagement matters more than attribution** — You want to know how many people visited your page and clicked links. You don't need to tie clicks to Stripe sales or specific campaigns.
+1. **You need a link-in-bio page** — You want one URL with a beautiful page, drag-and-drop editing, and free custom domains.
+2. **You're a creator or influencer** — You need a polished bio page for Instagram, TikTok, or LinkedIn. Deep linking ensures your audience lands in the right app.
+3. **You don't need revenue attribution** — You care about clicks and engagement, not tying activity to Stripe sales.
+4. **You want zero technical setup** — Sign up, add links, done. No integrations to configure.
+5. **Custom domains are important and you want them free** — Taap.it's free custom domains are a genuine differentiator.
 
 ## When to choose PIMMS
 
 PIMMS is the right choice if:
 
-1. **You sell online** — You want to know which link, campaign, or post drove each Stripe sale. Revenue attribution is PIMMS's strength.
-2. **You share links on social** — You want social-media deep linking that opens links directly inside YouTube, TikTok, Instagram, etc. PIMMS includes this on every plan — as does Taap.it. Both are among the few tools that support this.
-3. **You run campaigns** — You need UTM tracking, A/B testing, and webhooks to optimize which links convert. Taap.it doesn't offer these.
-4. **Ad blockers affect your data** — Server-side tracking means PIMMS can capture events that client-side tools miss.
-5. **You're budget-conscious** — Lifetime pricing (€79 or €129) or lower monthly fees for advanced tracking. Conversion tracking is free on PIMMS.
-6. **You already have a bio page** — If you use Taap.it, Linktree, a custom website, or another page builder, PIMMS tracks the links *inside* that page.
+1. **You sell online** — You need to know which link, campaign, or post drove each Stripe sale. Revenue attribution works on the free plan.
+2. **You're a B2B professional** — You share links in LinkedIn posts, email sequences, and outreach. You need to prove which activity generates pipeline. PIMMS tracks the full funnel.
+3. **You run e-commerce** — Product links across social, email, and ads. PIMMS attributes revenue to the right channel, post, and campaign.
+4. **You share links across multiple channels** — LinkedIn, email, Twitter, ads, SMS, QR codes at events. PIMMS tracks links everywhere, not just inside a bio page.
+5. **You run campaigns with UTMs** — PIMMS's UTM management replaces UTM.io and spreadsheets.
+6. **Ad blockers affect your data** — Server-side tracking captures events that client-side tools miss.
+7. **You want deep linking too** — PIMMS includes social-media deep linking (100+ apps) on every plan. You don't need Taap.it for deep linking.
+8. **Budget matters** — Lifetime pricing (€79 or €129 once) versus Taap.it's subscription.
+9. **You value transparency** — PIMMS is open-source.
 
-## Use them together: the best of both worlds
+## Can you use both?
 
-The most powerful setup often combines both tools. Smart marketers use both:
+Yes — but be honest about what each tool contributes.
 
-1. **Taap.it as your bio page** — Use Taap.it for your Instagram, TikTok, or LinkedIn bio. One URL, multiple links, social-media deep linking, QR codes, polished design, custom domain free.
-2. **PIMMS links inside Taap.it** — Replace raw URLs with PIMMS smart links. When someone clicks "Book a demo" or "Shop now," they hit a PIMMS link that redirects and tracks the click.
-3. **Revenue attribution** — Connect PIMMS to Stripe. Now you know which Taap.it link drove each sale, even though Taap.it itself doesn't track revenue.
-4. **Social-media deep linking** — Both Taap.it and PIMMS support social-media deep linking (opening links directly inside YouTube, TikTok, Instagram, etc.). This is a shared strength — few link tools offer this. So a "Watch on YouTube" link in your Taap.it page opens the YouTube app instead of a browser.
-5. **A/B testing** — Use PIMMS to A/B test different destinations for the same Taap.it button. Optimize without changing your Taap.it page.
+Use Taap.it for your bio page if you need one. Put PIMMS smart links inside it. When someone clicks a link on your Taap.it page, they hit PIMMS first (tracking the click and deep linking), then arrive at the destination. Connect PIMMS to Stripe, and you know which Taap.it link drove each sale.
 
-**Example workflow:** Your Taap.it page has buttons for "Book a demo," "Pricing," and "Latest video." Each button points to a PIMMS link. PIMMS tracks clicks, attributes Stripe sales to the right link, and can use social-media deep linking to open YouTube or other apps. Taap.it gives you the page; PIMMS gives you the intelligence.
+**But here's the reality:** PIMMS already has deep linking (100+ apps) and QR codes. If you don't specifically need a link-in-bio page, PIMMS alone covers everything Taap.it does for link tracking — and adds revenue attribution, UTM management, A/B testing, server-side tracking, and 15+ form integrations.
 
-**Setup steps:** Create your Taap.it page as usual. In PIMMS, create a smart link for each destination (demo booking, pricing page, YouTube video). Copy each PIMMS link URL and paste it into the corresponding Taap.it button. Connect PIMMS to Stripe if you sell online. That's it — no code, no technical setup. Your Taap.it page now has full attribution.
+The combination makes sense only if you genuinely need a bio page. If your links live in LinkedIn posts, email sequences, ads, or QR codes at events, PIMMS alone is the better choice.
 
-**Concrete example:** A creator uses Taap.it for their Instagram bio. The page has three buttons: "Book a call," "See my products," and "Watch my latest reel." Each button points to a PIMMS link. The call link goes to Cal.com; the products link goes to their Stripe checkout; the reel link goes to Instagram. PIMMS tracks every click, adds UTM parameters, and when someone books a call and later converts to a Stripe customer, PIMMS attributes that sale back to the "Book a call" link. The creator now knows exactly which Instagram posts drove revenue — something Taap.it alone cannot do.
+## Setup: PIMMS links inside Taap.it
+
+If you use both:
+
+1. **Create your Taap.it bio page** — Add your links, customize the design, set up your custom domain.
+2. **Create PIMMS smart links** for each destination (demo booking, pricing page, YouTube channel, product page).
+3. **Replace Taap.it URLs** with PIMMS link URLs. Each Taap.it button now points to a PIMMS smart link.
+4. **Connect PIMMS to Stripe** if you sell online.
+5. **Check PIMMS dashboard** — See clicks, leads, and revenue per link. Know exactly which bio page button drives sales.
+
+Your Taap.it page handles the visual experience. PIMMS handles the intelligence.
 
 ## Summary table
 
 | Criteria | Taap.it | PIMMS |
 |----------|---------|-------|
-| **Best for** | Link-in-bio page, creators, social-media deep linking, QR codes | Revenue tracking, campaign attribution, opt-in form tracking |
-| **Core product** | Page with multiple links | Individual tracked links |
-| **Free plan** | 5 links, 5 QR codes, 1 page, custom domains free | 5 links, 200 events, 1 domain, conversion tracking, social-media deep linking |
-| **Conversion tracking** | ❌ | ✅ All plans incl. Free |
-| **Custom domains** | ✅ Free on all plans | From Tiny (€9/mo) |
-| **Social-media deep linking** | ✅ 50+ apps | ✅ 100+ apps, all plans |
+| **Best for** | Bio page, creators, free custom domains | Revenue attribution, B2B, e-commerce, multi-channel tracking |
+| **Core product** | Link-in-bio page builder | Marketing attribution platform |
+| **Free plan** | 5 links, 5 QR codes, 1 page, custom domains free | 5 links, 200 events, 1 domain, conversion tracking, deep linking, Stripe integration |
+| **Deep linking** | ✅ 50+ apps | ✅ 100+ apps |
+| **QR codes** | ✅ 5 on Free | ✅ All plans |
+| **Conversion tracking (no-code)** | ❌ | ✅ All plans incl. Free |
+| **Conversion tracking (API)** | ✅ Lead & sale endpoints | ✅ Full API + no-code |
+| **Native Stripe integration** | ❌ | ✅ Free |
 | **UTM management** | ❌ | ✅ All plans |
 | **Server-side tracking** | ❌ | ✅ All plans |
-| **Opt-in form tracking** | ❌ | ✅ All plans incl. Free |
+| **Opt-in form tracking** | ❌ | ✅ 15+ native + 100 via Zapier/Make |
+| **A/B testing** | ❌ | ✅ Solo+ (€19/mo) |
+| **Custom domains free** | ✅ | 1 on Free, more on paid |
+| **Standalone tracked links** | ❌ (inside bio page) | ✅ Anywhere |
 | **Lifetime pricing** | ❌ | ✅ €79, €129 |
+| **Open source** | ❌ | ✅ |
 
 ## Conclusion
 
-Taap.it and PIMMS are not head-to-head competitors. Taap.it builds the link-in-bio page with social-media deep linking and QR codes; PIMMS tracks what happens after someone clicks. Choosing between them is the wrong question — the right question is: what do you need?
+Taap.it builds beautiful bio pages with deep linking and free custom domains. It's a solid choice for creators who need a link-in-bio page with a clean UI and quick setup.
 
-- **Need a bio page with social-media deep linking and free custom domains?** Taap.it is the answer. It's great for creators who need a beautiful link-in-bio page with minimal setup.
-- **Need revenue attribution, opt-in form tracking, or campaign tracking?** PIMMS is the answer. Conversion tracking is free; server-side tracking and UTM management are included on every plan.
-- **Need both?** Use Taap.it for the page and PIMMS links inside it. The combined cost is often lower than you'd expect, and you get the best of both tools.
+But if you need to know which links, campaigns, or posts drive actual revenue — **PIMMS is in a different league.** Native Stripe integration, no-code conversion tracking, server-side tracking, UTM management, A/B testing, 15+ form integrations, and lifetime pricing starting at €79. All of this on the free plan or for a one-time payment. Open-source, transparent, built for professionals who need results, not just clicks.
 
-Don't force one tool to do everything. Use each for what it does best, and you'll save time, money, and frustration.
+Taap.it recently added lead and sale tracking API endpoints — a step in the right direction. But API-only tracking that requires developer work is not the same as PIMMS's plug-and-play attribution. Most marketers will never implement Taap.it's tracking API. Every marketer can connect PIMMS to Stripe in 2 minutes.
+
+**If you're a creator who needs a bio page:** Taap.it is a good choice. Add PIMMS links inside it for tracking.
+
+**If you're a B2B professional or e-commerce marketer who needs ROI:** PIMMS. It does everything Taap.it does for link tracking — deep linking, QR codes — plus everything Taap.it doesn't: revenue attribution, UTM management, A/B testing, server-side tracking, and a complete conversion tracking ecosystem. At a fraction of the cost.
 
 ## FAQ
 
 ::: faq
 ### Are Taap.it and PIMMS competitors?
-No. They solve different problems. Taap.it builds the link-in-bio page that hosts your links, with social-media deep linking and QR codes. PIMMS creates tracked links that measure clicks and revenue. Both support social-media deep linking - a shared strength. They're complementary: use Taap.it for your bio page, PIMMS links inside it for tracking.
+Partially. Both offer deep linking and QR codes. But Taap.it's core product is a link-in-bio page builder, while PIMMS is a marketing attribution platform. They overlap on links, but PIMMS adds revenue tracking, UTM management, A/B testing, and server-side tracking. You can use both — Taap.it for the page, PIMMS for the intelligence.
+:::
+
+::: faq
+### Does Taap.it have conversion tracking?
+Taap.it has API endpoints for tracking leads and sales (POST to their events API). However, this requires custom development — integrating their SDK, managing tracking IDs, and writing code to send events. There's no native Stripe integration and no no-code setup. PIMMS includes native Stripe integration and no-code conversion tracking on the free plan.
+:::
+
+::: faq
+### Both have deep linking — what's the difference?
+Both bypass in-app browsers and open links in native apps. Taap.it supports 50+ apps; PIMMS supports 100+. The key difference: Taap.it deep links only work inside bio pages. PIMMS deep links work in any smart link — shared in LinkedIn posts, emails, ads, SMS, QR codes, anywhere. Plus, PIMMS adds conversion tracking to every deep link.
 :::
 
 ::: faq
 ### Can I use PIMMS links inside my Taap.it page?
-Yes. Replace any URL in your Taap.it page with a PIMMS smart link. When visitors click, they're redirected through PIMMS, which tracks the click and can attribute revenue. You get Taap.it's page design with PIMMS's attribution.
+Yes. Replace any URL in your Taap.it page with a PIMMS smart link. Visitors click, pass through PIMMS (which tracks the click and handles deep linking), and arrive at the destination. You get Taap.it's page design with PIMMS's revenue attribution.
 :::
 
 ::: faq
-### Does Taap.it track revenue or conversions?
-No. Taap.it tracks page views, link clicks, and device/geo analytics. It does not connect clicks to Stripe or any payment platform. For revenue attribution, you need a tool like PIMMS.
-:::
-
-::: faq
-### Does Taap.it support social-media deep linking?
-Yes. Both Taap.it and PIMMS support social-media deep linking — opening links directly inside YouTube, TikTok, Instagram, and 50+ (Taap.it) or 100+ (PIMMS) apps. They are among the few link tools that offer this capability (vs. app deep linking for iOS/Android).
+### Which has better QR codes?
+Both generate QR codes. PIMMS QR codes are branded and tracked with the same conversion tracking as regular links — so you can attribute Stripe sales to a specific QR code. Taap.it QR codes track clicks and device/geo but don't connect to revenue.
 :::
 
 ::: faq
 ### Does PIMMS offer conversion tracking on the free plan?
-Yes. PIMMS includes conversion tracking, Stripe integration, opt-in form tracking, server-side tracking, and social-media deep linking on the free plan. Taap.it does not offer conversion tracking at any price, but both support social-media deep linking.
+Yes. PIMMS includes Stripe integration, conversion tracking, lead capture from forms, server-side tracking, and deep linking on the free plan. Taap.it's free plan includes a bio page, deep linking, and basic analytics — but no conversion tracking.
 :::
 
 ::: faq
-### Which is better for creators?
-Taap.it is better if you need a polished bio page, free custom domains, social-media deep linking, and QR codes with minimal setup. PIMMS is better if you need to know which links drive revenue (e.g. affiliate links, product links). Both support social-media deep linking — a shared strength. Many creators use both: Taap.it for the page, PIMMS for the links that matter for revenue.
+### Which is better for B2B professionals?
+PIMMS. B2B professionals share links in LinkedIn posts, email sequences, and outreach campaigns — not just in a bio page. PIMMS tracks links across all channels, attributes leads and revenue to specific campaigns, and provides UTM management for team-wide consistency. Taap.it is a bio page tool.
 :::
 
 ::: faq
-### Which is better for SaaS founders?
-PIMMS. SaaS founders typically need revenue attribution (which link drove this Stripe sale?), UTM tracking, A/B testing, and opt-in form tracking. Taap.it doesn't offer these. You might still use Taap.it (or a custom page) for your bio, but PIMMS tracks the links.
+### Which is better for e-commerce?
+PIMMS. E-commerce marketers need to attribute revenue to the right channel, campaign, and creative. PIMMS connects Stripe sales to specific links and campaigns. Taap.it builds bio pages — useful for Instagram commerce, but it can't tell you which link generated a sale without custom API development.
 :::
 
 ::: faq
 ### What's PIMMS lifetime pricing?
-PIMMS Tiny is €79 one-time (100 links/mo, 1 custom domain, 1 year retention). PIMMS Solo is €129 one-time (500 links/mo, 3 domains, Stripe sales tracking, A/B testing, webhooks, 5 team members). Taap.it does not offer lifetime pricing; paid plans are subscription-based.
+PIMMS Tiny is €79 one-time (100 links/mo, 1 custom domain, 1 year data retention). PIMMS Solo is €129 one-time (500 links/mo, 3 domains, A/B testing, webhooks, 5 team members). Taap.it is subscription-only with paid plan pricing not fully public.
 :::
 
 ::: faq
-### How do I get started with Taap.it + PIMMS?
-1. Create a Taap.it account (free) and build your bio page. 2. Create a PIMMS account (free) and create a smart link for each destination (demo, pricing, YouTube, etc.). 3. Copy each PIMMS link URL and paste it into the corresponding Taap.it button. 4. If you sell online, connect PIMMS to Stripe. 5. Upgrade when you need more: PIMMS Solo for A/B testing and webhooks, Taap.it paid for higher limits.
+### Do I need Taap.it if I already use PIMMS?
+Only if you need a link-in-bio page. PIMMS already includes deep linking (100+ apps), QR codes, and tracked links. If your links live in posts, emails, and ads rather than a bio page, PIMMS alone covers everything — with revenue attribution that Taap.it doesn't match.
 :::

--- a/content/fr/blog/taapit-vs-pimms-comparison-2026.mdx
+++ b/content/fr/blog/taapit-vs-pimms-comparison-2026.mdx
@@ -1,0 +1,303 @@
+---
+title: "Taap.it vs PIMMS 2026 : outil link-in-bio vs attribution marketing complète — lequel prouve votre ROI ?"
+summary: "Taap.it construit des pages bio avec deep linking. PIMMS traque chaque clic du premier contact au paiement Stripe. Voici pourquoi les professionnels B2B et e-commerce choisissent PIMMS."
+publishedAt: 2026-02-19
+updatedAt: 2026-02-21
+slug: taapit-vs-pimms-comparison-2026
+image: /static/taapit-vs-pimms-comparison-2026.webp
+author: alexandre
+categories:
+  - digital-marketing
+  - tool-comparison
+related:
+  - linktree-vs-pimms-comparison-2026
+  - bitly-vs-pimms-what-founders-really-need-beyond-click-tracking
+  - how-to-track-link-performance-across-multiple-channels
+  - from-first-click-to-conversion-understand-exactly-how-your-marketing-drives-revenue
+seoTitle: "Taap.it vs PIMMS 2026 : comparaison honnête pour les marketeurs orientés ROI"
+description: "Taap.it est un constructeur de link-in-bio français avec deep linking. PIMMS est une plateforme d'attribution marketing open-source. Comparez les prix, les fonctionnalités, et découvrez lequel prouve vraiment votre ROI marketing."
+---
+
+Taap.it et PIMMS gèrent tous les deux des liens, du deep linking, et des QR codes — mais c'est là que la ressemblance s'arrête. Taap.it construit la page qui héberge vos liens. PIMMS traque le parcours complet du clic au revenu. Si vous devez prouver votre ROI marketing, cette comparaison compte.
+
+**En résumé :** Taap.it est un constructeur de link-in-bio français avec deep linking sur les réseaux sociaux et QR codes — interface propre, domaines personnalisés gratuits, idéal pour les créateurs qui ont besoin d'une page bio. PIMMS est une plateforme d'attribution marketing open-source qui traque les clics, capture des leads, et attribue les revenus Stripe au lien, campagne ou post exact qui a généré la vente. PIMMS est moins cher (pricing lifetime dès 79€), plus puissant pour le tracking, et essentiel pour quiconque vend en ligne. Les deux supportent le deep linking et les QR codes — mais PIMMS ajoute l'intelligence revenus que Taap.it n'offre pas en pratique.
+
+## La différence fondamentale : constructeur de page bio vs attribution marketing
+
+**Taap.it** est un constructeur de link-in-bio français. Vous obtenez une URL unique (ex : `taap.it/votrenom`) avec une belle page hébergeant plusieurs liens, un éditeur drag-and-drop, du deep linking réseaux sociaux (50+ apps), et des QR codes. Les domaines personnalisés sont gratuits sur tous les plans — un vrai point fort. Les analytics couvrent les clics, visiteurs uniques, et répartitions appareil/géo. Taap.it a récemment ajouté des endpoints de tracking lead et vente dans leur API (voir leur [documentation](https://docs.taap.it)), mais ceux-ci nécessitent du développement custom — appels API, intégration SDK, gestion de cookies — sans intégration native Stripe ni guides de setup no-code. Pour la plupart des utilisateurs, Taap.it reste un constructeur de page bio avec des analytics basiques.
+
+**PIMMS** est une plateforme open-source de tracking de liens et d'attribution de revenus ([GitHub](https://github.com/pimmsio/getpimms)). Vous créez des liens intelligents qui traquent chaque clic, capturent des leads depuis les formulaires et réservations, deep-linkent dans 100+ apps, et attribuent les revenus Stripe au post, campagne ou email exact qui a généré la vente. Le focus est sur le funnel complet : clic → visite page → soumission formulaire → paiement Stripe. Aucun développement requis — connectez Stripe en quelques clics, suivez les guides pas à pas pour 15+ outils de formulaires et réservations, et voyez le revenu par lien immédiatement.
+
+**La différence clé n'est pas les fonctionnalités — c'est l'accessibilité.** Sur le papier, Taap.it a des endpoints API de tracking lead/vente. En pratique, les utiliser nécessite un développeur, du code d'intégration custom, et de la gestion de cookies/tracking IDs. PIMMS donne le même résultat — l'attribution de revenus — sans code, sur le plan gratuit.
+
+## Comparaison des prix (vérifiés en février 2026)
+
+### Plans Taap.it
+
+La page de pricing de Taap.it est partiellement restreinte, mais voici ce qui est public :
+
+| Plan | Prix | Liens | QR codes | Pages bio |
+|------|------|-------|----------|-----------|
+| **Free** | 0€ | 5 | 5 | 1 |
+| **Starter** | Payant (prix non entièrement public) | Plus | Plus | Plus |
+| **Pro** | Payant (prix non entièrement public) | Plus | Plus | Plus |
+| **Business** | Payant (prix non entièrement public) | Plus | Plus | Plus |
+
+**Le plan gratuit inclut :** 5 liens, 5 QR codes, 1 page link-in-bio, domaines personnalisés gratuits, deep linking réseaux sociaux (50+ apps), analytics basiques (clics, visiteurs uniques, appareil/géo), éditeur drag-and-drop.
+
+**Ce qui manque à tous les paliers :** Pas d'intégration native Stripe. Pas de tracking de conversion no-code. Pas de gestion UTM. Pas d'A/B testing. Pas de tracking server-side. Pas de guides de tracking formulaires. Le tracking lead/vente existe uniquement comme endpoints API nécessitant du développement custom.
+
+### Plans PIMMS
+
+| Plan | Mensuel | Lifetime | Liens/mois | Événements/mois | Domaines | Utilisateurs |
+|------|---------|----------|------------|-----------------|----------|-------------|
+| **Free** | 0€ | — | 5 | 200 | 1 | 1 |
+| **Tiny** | 9€/mois | **79€ une fois** | 100 | 1 500 | 1 | 1 |
+| **Solo** | 19€/mois | **129€ une fois** | 500 | 3 000 | 3 | 5 |
+| **Pro** | 39€/mois | 390€/an | 1 000 | 10 000 | 5 | 5 |
+| **Business** | 69€/mois | 690€/an | 2 000 | 20 000 | 10 | 10 |
+
+**Ce qui ressort :**
+
+- **PIMMS Free inclut le tracking de conversion, l'intégration Stripe, le deep linking, le tracking server-side, et le tracking de formulaires.** Taap.it Free donne une page bio avec des analytics basiques.
+- **PIMMS a un pricing lifetime** — Tiny à 79€ ou Solo à 129€, paiement unique, à utiliser pour toujours. Taap.it est en abonnement uniquement.
+- **PIMMS Solo (129€ une fois)** donne 500 liens/mois, 3 domaines personnalisés, A/B testing, webhooks, et 5 membres d'équipe. À vie. Aucun plan Taap.it n'offre d'A/B testing, de webhooks, ou de gestion UTM à aucun prix.
+- **Domaines personnalisés :** Taap.it les inclut gratuitement (un plus). PIMMS inclut 1 sur Free et plus dès Tiny (9€/mois).
+
+## Comparaison des fonctionnalités
+
+| Fonctionnalité | Taap.it | PIMMS |
+|---------------|---------|-------|
+| **Page link-in-bio** | ✅ Produit principal | ❌ |
+| **Éditeur drag-and-drop** | ✅ | ❌ |
+| **Domaines personnalisés** | ✅ Gratuits sur tous les plans | ✅ 1 sur Free, plus dès Tiny |
+| **Deep linking réseaux sociaux** | ✅ 50+ apps | ✅ 100+ apps, tous les plans |
+| **QR codes** | ✅ 5 sur Free | ✅ Tous les plans, illimités sur payant |
+| **Analytics basiques (clics, appareil, géo)** | ✅ Tous les plans | ✅ Tous les plans |
+| **Liens trackés autonomes** | ❌ (les liens vivent dans la page bio) | ✅ Tous les plans |
+| **Tracking de conversion (no-code)** | ❌ | ✅ Tous les plans y compris Free |
+| **Tracking de conversion (API)** | ✅ Endpoints lead et vente | ✅ API complète + no-code |
+| **Intégration native Stripe** | ❌ | ✅ Tous les plans y compris Free |
+| **Attribution des revenus par lien/campagne** | ❌ (nécessite dev custom) | ✅ Tous les plans y compris Free |
+| **UTM builder + templates** | ❌ | ✅ Tous les plans |
+| **Paramètres UTM sauvegardés** | ❌ | ✅ Tous les plans (10 sur Free) |
+| **Filtrer/trier/grouper par UTM** | ❌ | ✅ Tous les plans |
+| **Tracking server-side** | ❌ | ✅ Tous les plans y compris Free |
+| **Tracking formulaires opt-in (15+ outils)** | ❌ | ✅ Stripe, Tally, Cal.com, Calendly, Brevo, Webflow, Framer, Elementor, Systeme.io, Podia, iClosed + 100 via Zapier/Make |
+| **A/B testing** | ❌ | ✅ Solo+ (19€/mois) |
+| **Webhooks** | ❌ | ✅ Solo+ (19€/mois) |
+| **100+ intégrations (Zapier, Make)** | ❌ | ✅ Tous les plans |
+| **Open source** | ❌ | ✅ ([GitHub](https://github.com/pimmsio/getpimms)) |
+| **Prix lifetime** | ❌ | ✅ 79€, 129€ |
+
+### Les deux outils supportent le deep linking et les QR codes
+
+C'est important : **PIMMS a aussi le deep linking réseaux sociaux (100+ apps) et les QR codes sur chaque plan.** Les deux outils contournent les navigateurs in-app et ouvrent les liens directement dans YouTube, TikTok, Instagram, Amazon, etc. PIMMS supporte plus d'apps (100+ vs 50+), et chaque lien PIMMS bénéficie automatiquement du deep linking — pas uniquement les liens dans une page bio.
+
+Les deux outils génèrent aussi des QR codes. Les QR codes PIMMS sont personnalisés et trackés avec le même tracking de conversion et attribution que les liens normaux.
+
+### Où Taap.it gagne
+
+- **Page link-in-bio** — Le produit principal de Taap.it est une belle page bio personnalisable avec un éditeur drag-and-drop. PIMMS crée des liens trackés individuels, pas des pages.
+- **Domaines personnalisés gratuits** — Même sur le plan gratuit. PIMMS nécessite Tiny (9€/mois) pour des domaines supplémentaires au-delà du premier.
+- **Facilité de setup pour les pages bio** — Moins de 5 minutes. Aucune connaissance technique. Inscription, ajout de liens, personnalisation, c'est fait.
+- **UI propre made in France** — Interface moderne, équipe support réactive, communauté active sur Discord.
+
+### Où PIMMS gagne — nettement
+
+- **Attribution de revenus no-code (gratuit)** — Connectez Stripe en quelques clics. Voyez quel lien, campagne ou post a généré chaque paiement. C'est le point fort de PIMMS. Taap.it a des endpoints API pour le tracking de ventes, mais les utiliser requiert un développeur pour implémenter la gestion de cookies, le passage de tracking IDs, et les appels API. La plupart des utilisateurs Taap.it ne feront jamais ça.
+- **Écosystème de tracking formulaires (gratuit)** — Guides pas à pas pour Stripe, Tally, Cal.com, Calendly, Brevo, Webflow, Framer, Elementor, Systeme.io, Podia, iClosed, plus 100+ via Zapier/Make. Connectez vos formulaires, voyez quel lien a généré chaque lead. Taap.it n'a rien de tout ça.
+- **Tracking server-side (gratuit)** — Les bloqueurs de pub et protections vie privée bloquent les analytics côté client. PIMMS traque via des événements server-side. Vos données restent précises. Taap.it dépend entièrement du tracking côté client.
+- **Gestion UTM professionnelle** — Builder UTM visuel, templates réutilisables, paramètres sauvegardés, filtrer/trier/grouper par UTM, génération en masse, export CSV. Sur Pro+ : conventions de nommage et règles de validation. Remplace UTM.io ($19–$159/mois) et les tableurs. Taap.it n'a aucune gestion UTM.
+- **A/B testing** — Testez différentes destinations et mesurez les conversions. Taap.it ne propose pas ça.
+- **Webhooks & API** — Support complet des webhooks, intégrations Zapier/Make, API REST. Automatisez les workflows, synchronisez avec les CRMs. L'API de Taap.it est centrée sur la gestion de liens, pas l'automatisation de workflows.
+- **Liens intelligents autonomes** — Les liens PIMMS fonctionnent partout : posts LinkedIn, séquences email, publicités, SMS, Twitter, sites partenaires, QR codes en événements. Les liens Taap.it vivent dans les pages bio — vous ne pouvez pas facilement partager un lien Taap.it tracké dans une campagne email.
+- **Prix lifetime** — 79€ (Tiny) ou 129€ (Solo) une fois. Taap.it est en abonnement uniquement.
+- **Open source** — Inspectez le code, auto-hébergez, personnalisez. Taap.it est closed-source.
+
+## L'écart du tracking de conversion
+
+C'est la plus grande différence et elle mérite une explication détaillée.
+
+**Taap.it** a récemment livré des endpoints API de tracking lead et vente. Sur le papier, ça ressemble à du tracking de conversion. En pratique, voici ce qui est requis :
+
+1. Un développeur intègre le SDK ou l'API Taap.it dans votre site
+2. Votre site lit le tracking ID `ta_tid` depuis les cookies ou paramètres d'URL
+3. Quand un lead se convertit ou une vente a lieu, votre code envoie une requête POST à l'API Taap.it avec le tracking ID, les infos client, et le montant de la vente
+4. Il n'y a pas d'intégration native avec Stripe, Tally, Cal.com, ou aucun autre outil — vous écrivez le code d'interconnexion vous-même
+
+C'est une approche développeur-first. Ça marche si vous avez des ressources d'ingénierie. La plupart des marketeurs, fondateurs et petites équipes n'en ont pas.
+
+**PIMMS** prend l'approche opposée :
+
+1. Connectez Stripe en quelques clics (sans code)
+2. Suivez un guide pas à pas pour votre outil de formulaires (Tally, Cal.com, Calendly, Brevo, Webflow, Framer, etc.)
+3. L'attribution de revenus apparaît automatiquement dans votre dashboard — par lien, par campagne, par paramètre UTM
+4. Le tracking server-side assure la précision même avec les bloqueurs de pub
+5. Tout ça fonctionne sur le **plan gratuit**
+
+Le résultat : PIMMS vous donne l'attribution de revenus aujourd'hui, sans développeur. Taap.it vous donne des endpoints API que vous utiliserez peut-être un jour si vous construisez l'intégration.
+
+## Écosystème de tracking formulaires PIMMS
+
+Un des plus gros différenciateurs de PIMMS — disponible sur tous les plans, y compris Free :
+
+- **Paiements :** Stripe, Podia, Shopify
+- **Formulaires & leads :** Tally, Brevo, Webflow, Framer, Elementor, Systeme.io
+- **Réservation :** Cal.com, Calendly, iClosed
+- **100+ autres** via Zapier et Make
+
+Chaque intégration a un guide de setup dédié. Connectez une fois, et chaque lead ou vente est automatiquement attribué au lien qui l'a généré. Pas de code custom, pas de développeur nécessaire.
+
+Taap.it n'a pas d'équivalent. Leurs endpoints API nécessitent de tout construire soi-même.
+
+## Gestion UTM professionnelle
+
+La plupart des outils de liens offrent au mieux un builder UTM basique. PIMMS traite la gestion UTM comme une fonctionnalité de premier plan :
+
+**Sur tous les plans (y compris Free) :**
+
+- **Builder UTM** — Éditeur visuel, pas de construction d'URL manuelle
+- **Templates UTM** — Sauvegardez des sets de paramètres réutilisables, appliquez en un clic (3 sur Free, illimités sur payant)
+- **Paramètres UTM sauvegardés** — Pré-remplissez des valeurs cohérentes dans toute votre équipe (10 sur Free, illimités sur payant)
+- **Filtrer, trier & grouper par UTM** — Découpez vos analytics par source, medium, campagne, terme, contenu
+- **Builder UTM en masse** — Collez des URLs ou importez un CSV, appliquez des templates, générez des dizaines de liens trackés
+- **Export CSV** — Exportez tous les liens et données UTM
+
+**Sur Pro+ (39€/mois) :**
+
+- **Conventions UTM** — Exigez, verrouillez, masquez, validez les paramètres. Imposez une taxonomie de nommage.
+- **Règles UTM** — Définissez les valeurs autorisées par type de campagne
+
+Ça remplace UTM.io ($19–$159/mois) et le tracking sur tableur. Taap.it n'a aucune gestion UTM.
+
+## Quand choisir Taap.it
+
+Taap.it est le bon choix si :
+
+1. **Vous avez besoin d'une page link-in-bio** — Vous voulez une URL unique avec une belle page, édition drag-and-drop, et domaines personnalisés gratuits.
+2. **Vous êtes créateur ou influenceur** — Vous avez besoin d'une page bio soignée pour Instagram, TikTok, ou LinkedIn. Le deep linking assure que votre audience atterrit dans la bonne app.
+3. **Vous n'avez pas besoin d'attribution de revenus** — Vous vous souciez des clics et de l'engagement, pas de relier l'activité aux ventes Stripe.
+4. **Vous voulez zéro setup technique** — Inscription, ajout de liens, c'est fait. Pas d'intégrations à configurer.
+5. **Les domaines personnalisés sont importants et vous les voulez gratuits** — Les domaines gratuits de Taap.it sont un vrai différenciateur.
+
+## Quand choisir PIMMS
+
+PIMMS est le bon choix si :
+
+1. **Vous vendez en ligne** — Vous devez savoir quel lien, campagne ou post a généré chaque vente Stripe. L'attribution de revenus fonctionne sur le plan gratuit.
+2. **Vous êtes un professionnel B2B** — Vous partagez des liens dans des posts LinkedIn, séquences email, et campagnes d'outreach. Vous devez prouver quelle activité génère du pipeline. PIMMS traque le funnel complet.
+3. **Vous faites du e-commerce** — Liens produits sur les réseaux sociaux, email, et publicités. PIMMS attribue le revenu au bon canal, post, et campagne.
+4. **Vous partagez des liens sur plusieurs canaux** — LinkedIn, email, Twitter, publicités, SMS, QR codes en événements. PIMMS traque les liens partout, pas juste dans une page bio.
+5. **Vous gérez des campagnes avec UTMs** — La gestion UTM de PIMMS remplace UTM.io et les tableurs.
+6. **Les bloqueurs de pub affectent vos données** — Le tracking server-side capture les événements que les outils côté client ratent.
+7. **Vous voulez aussi du deep linking** — PIMMS inclut le deep linking réseaux sociaux (100+ apps) sur chaque plan. Vous n'avez pas besoin de Taap.it pour le deep linking.
+8. **Le budget compte** — Prix lifetime (79€ ou 129€ une fois) versus l'abonnement Taap.it.
+9. **Vous valorisez la transparence** — PIMMS est open-source.
+
+## Peut-on utiliser les deux ?
+
+Oui — mais soyons honnêtes sur ce que chaque outil apporte.
+
+Utilisez Taap.it pour votre page bio si vous en avez besoin. Mettez des liens intelligents PIMMS dedans. Quand quelqu'un clique un lien sur votre page Taap.it, il passe par PIMMS d'abord (tracking du clic et deep linking), puis arrive à destination. Connectez PIMMS à Stripe, et vous savez quel lien Taap.it a généré chaque vente.
+
+**Mais voilà la réalité :** PIMMS a déjà le deep linking (100+ apps) et les QR codes. Si vous n'avez pas spécifiquement besoin d'une page link-in-bio, PIMMS seul couvre tout ce que Taap.it fait pour le tracking de liens — et ajoute l'attribution de revenus, la gestion UTM, l'A/B testing, le tracking server-side, et 15+ intégrations de formulaires.
+
+La combinaison a du sens uniquement si vous avez vraiment besoin d'une page bio. Si vos liens vivent dans des posts LinkedIn, séquences email, publicités, ou QR codes en événements, PIMMS seul est le meilleur choix.
+
+## Setup : liens PIMMS dans Taap.it
+
+Si vous utilisez les deux :
+
+1. **Créez votre page bio Taap.it** — Ajoutez vos liens, personnalisez le design, configurez votre domaine.
+2. **Créez des liens intelligents PIMMS** pour chaque destination (réservation démo, page pricing, chaîne YouTube, page produit).
+3. **Remplacez les URLs Taap.it** par les URLs de liens PIMMS. Chaque bouton Taap.it pointe maintenant vers un lien intelligent PIMMS.
+4. **Connectez PIMMS à Stripe** si vous vendez en ligne.
+5. **Consultez le dashboard PIMMS** — Voyez les clics, leads, et revenus par lien. Sachez exactement quel bouton de votre page bio génère des ventes.
+
+Votre page Taap.it gère l'expérience visuelle. PIMMS gère l'intelligence.
+
+## Tableau récapitulatif
+
+| Critère | Taap.it | PIMMS |
+|---------|---------|-------|
+| **Idéal pour** | Page bio, créateurs, domaines personnalisés gratuits | Attribution de revenus, B2B, e-commerce, tracking multi-canal |
+| **Produit principal** | Constructeur de page link-in-bio | Plateforme d'attribution marketing |
+| **Plan gratuit** | 5 liens, 5 QR codes, 1 page, domaines gratuits | 5 liens, 200 événements, 1 domaine, tracking conversion, deep linking, intégration Stripe |
+| **Deep linking** | ✅ 50+ apps | ✅ 100+ apps |
+| **QR codes** | ✅ 5 sur Free | ✅ Tous les plans |
+| **Tracking conversion (no-code)** | ❌ | ✅ Tous les plans y compris Free |
+| **Tracking conversion (API)** | ✅ Endpoints lead et vente | ✅ API complète + no-code |
+| **Intégration native Stripe** | ❌ | ✅ Gratuit |
+| **Gestion UTM** | ❌ | ✅ Tous les plans |
+| **Tracking server-side** | ❌ | ✅ Tous les plans |
+| **Tracking formulaires opt-in** | ❌ | ✅ 15+ natifs + 100 via Zapier/Make |
+| **A/B testing** | ❌ | ✅ Solo+ (19€/mois) |
+| **Domaines personnalisés gratuits** | ✅ | 1 sur Free, plus sur payant |
+| **Liens trackés autonomes** | ❌ (dans la page bio) | ✅ Partout |
+| **Prix lifetime** | ❌ | ✅ 79€, 129€ |
+| **Open source** | ❌ | ✅ |
+
+## Conclusion
+
+Taap.it construit de belles pages bio avec deep linking et domaines personnalisés gratuits. C'est un bon choix pour les créateurs qui ont besoin d'une page link-in-bio avec une interface propre et un setup rapide.
+
+Mais si vous devez savoir quels liens, campagnes ou posts génèrent réellement du revenu — **PIMMS joue dans une autre catégorie.** Intégration native Stripe, tracking de conversion no-code, tracking server-side, gestion UTM, A/B testing, 15+ intégrations de formulaires, et pricing lifetime dès 79€. Tout ça sur le plan gratuit ou en paiement unique. Open-source, transparent, construit pour les professionnels qui ont besoin de résultats, pas juste de clics.
+
+Taap.it a récemment ajouté des endpoints API de tracking lead et vente — un pas dans la bonne direction. Mais du tracking API-only qui nécessite un développeur n'est pas la même chose que l'attribution plug-and-play de PIMMS. La plupart des marketeurs n'implémenteront jamais l'API de tracking de Taap.it. Tout marketeur peut connecter PIMMS à Stripe en 2 minutes.
+
+**Si vous êtes créateur et avez besoin d'une page bio :** Taap.it est un bon choix. Ajoutez des liens PIMMS dedans pour le tracking.
+
+**Si vous êtes professionnel B2B ou marketeur e-commerce et avez besoin de ROI :** PIMMS. Il fait tout ce que Taap.it fait pour le tracking de liens — deep linking, QR codes — plus tout ce que Taap.it ne fait pas : attribution de revenus, gestion UTM, A/B testing, tracking server-side, et un écosystème complet de tracking de conversion. À une fraction du coût.
+
+## FAQ
+
+::: faq
+### Taap.it et PIMMS sont-ils concurrents ?
+Partiellement. Les deux offrent du deep linking et des QR codes. Mais le produit principal de Taap.it est un constructeur de page link-in-bio, tandis que PIMMS est une plateforme d'attribution marketing. Ils se chevauchent sur les liens, mais PIMMS ajoute le tracking de revenus, la gestion UTM, l'A/B testing, et le tracking server-side. Vous pouvez utiliser les deux — Taap.it pour la page, PIMMS pour l'intelligence.
+:::
+
+::: faq
+### Taap.it a-t-il du tracking de conversion ?
+Taap.it a des endpoints API pour tracker leads et ventes (POST vers leur API events). Cependant, cela nécessite du développement custom — intégrer leur SDK, gérer les tracking IDs, et écrire du code pour envoyer les événements. Il n'y a pas d'intégration native Stripe ni de setup no-code. PIMMS inclut l'intégration native Stripe et le tracking de conversion no-code sur le plan gratuit.
+:::
+
+::: faq
+### Les deux ont le deep linking — quelle est la différence ?
+Les deux contournent les navigateurs in-app et ouvrent les liens dans les apps natives. Taap.it supporte 50+ apps ; PIMMS supporte 100+. La différence clé : les deep links Taap.it fonctionnent uniquement dans les pages bio. Les deep links PIMMS fonctionnent dans tout lien intelligent — partagé dans des posts LinkedIn, emails, publicités, SMS, QR codes, partout. En plus, PIMMS ajoute le tracking de conversion à chaque deep link.
+:::
+
+::: faq
+### Puis-je utiliser des liens PIMMS dans ma page Taap.it ?
+Oui. Remplacez n'importe quelle URL dans votre page Taap.it par un lien intelligent PIMMS. Les visiteurs cliquent, passent par PIMMS (qui traque le clic et gère le deep linking), et arrivent à destination. Vous obtenez le design de page Taap.it avec l'attribution de revenus PIMMS.
+:::
+
+::: faq
+### Lequel a de meilleurs QR codes ?
+Les deux génèrent des QR codes. Les QR codes PIMMS sont personnalisés et trackés avec le même tracking de conversion que les liens normaux — vous pouvez attribuer des ventes Stripe à un QR code spécifique. Les QR codes Taap.it traquent les clics et appareil/géo mais ne se connectent pas au revenu.
+:::
+
+::: faq
+### PIMMS offre-t-il du tracking de conversion sur le plan gratuit ?
+Oui. PIMMS inclut l'intégration Stripe, le tracking de conversion, la capture de leads depuis les formulaires, le tracking server-side, et le deep linking sur le plan gratuit. Le plan gratuit de Taap.it inclut une page bio, le deep linking, et des analytics basiques — mais pas de tracking de conversion.
+:::
+
+::: faq
+### Lequel est mieux pour les professionnels B2B ?
+PIMMS. Les professionnels B2B partagent des liens dans des posts LinkedIn, séquences email, et campagnes d'outreach — pas juste dans une page bio. PIMMS traque les liens sur tous les canaux, attribue leads et revenus à des campagnes spécifiques, et fournit une gestion UTM pour la cohérence d'équipe. Taap.it est un outil de page bio.
+:::
+
+::: faq
+### Lequel est mieux pour le e-commerce ?
+PIMMS. Les marketeurs e-commerce doivent attribuer le revenu au bon canal, campagne et créatif. PIMMS connecte les ventes Stripe à des liens et campagnes spécifiques. Taap.it construit des pages bio — utile pour le commerce Instagram, mais ne peut pas vous dire quel lien a généré une vente sans développement API custom.
+:::
+
+::: faq
+### Quel est le pricing lifetime de PIMMS ?
+PIMMS Tiny coûte 79€ une fois (100 liens/mois, 1 domaine personnalisé, 1 an de rétention de données). PIMMS Solo coûte 129€ une fois (500 liens/mois, 3 domaines, A/B testing, webhooks, 5 membres d'équipe). Taap.it est en abonnement uniquement avec les prix des plans payants non entièrement publics.
+:::
+
+::: faq
+### Ai-je besoin de Taap.it si j'utilise déjà PIMMS ?
+Uniquement si vous avez besoin d'une page link-in-bio. PIMMS inclut déjà le deep linking (100+ apps), les QR codes, et les liens trackés. Si vos liens vivent dans des posts, emails, et publicités plutôt que dans une page bio, PIMMS seul couvre tout — avec une attribution de revenus que Taap.it n'égale pas.
+:::

--- a/i18n/pathnames.ts
+++ b/i18n/pathnames.ts
@@ -2,22 +2,22 @@ export const pathnames: Record<string, Record<string, string>> = {
   "/": {
     "en": "/",
     "fr": "/",
-    "lastmod": "2026-02-20T00:00:00.000Z"
+    "lastmod": "2026-02-21T00:00:00.000Z"
   },
   "/freetools/site-checker": {
     "en": "/freetools/pimms-tracking-site-checker-install",
     "fr": "/freetools/pimms-tracking-site-checker-installation",
-    "lastmod": "2026-02-20T00:00:00.000Z"
+    "lastmod": "2026-02-21T00:00:00.000Z"
   },
   "/articles": {
     "en": "/articles",
     "fr": "/articles",
-    "lastmod": "2026-02-19T00:00:00.000Z"
+    "lastmod": "2026-02-21T00:00:00.000Z"
   },
   "/articles/category/digital-marketing": {
     "en": "/blog/marketing",
     "fr": "/blog/marketing",
-    "lastmod": "2026-02-19T00:00:00.000Z"
+    "lastmod": "2026-02-21T00:00:00.000Z"
   },
   "/articles/category/legal": {
     "en": "/legal",
@@ -27,7 +27,7 @@ export const pathnames: Record<string, Record<string, string>> = {
   "/articles/author/alexandre": {
     "en": "/articles/author/alexandre",
     "fr": "/articles/auteur/alexandre",
-    "lastmod": "2026-02-19T00:00:00.000Z"
+    "lastmod": "2026-02-21T00:00:00.000Z"
   },
   "/articles/author/emma": {
     "en": "/articles/author/emma",
@@ -47,7 +47,7 @@ export const pathnames: Record<string, Record<string, string>> = {
   "/articles/category/tool-comparison": {
     "en": "/tools",
     "fr": "/outils",
-    "lastmod": "2026-02-19T00:00:00.000Z"
+    "lastmod": "2026-02-21T00:00:00.000Z"
   },
   "/articles/5-dynamic-link-personalization-tips-for-higher-conversions": {
     "en": "/blog/5-dynamic-link-personalization-tips-for-higher-conversions",
@@ -308,7 +308,8 @@ export const pathnames: Record<string, Record<string, string>> = {
   },
   "/articles/taapit-vs-pimms-comparison-2026": {
     "en": "/blog/taapit-vs-pimms-comparison-2026",
-    "lastmod": "2026-02-19T00:00:00.000Z"
+    "lastmod": "2026-02-21T00:00:00.000Z",
+    "fr": "/blog/taapit-vs-pimms-comparison-2026"
   },
   "/articles/the-best-way-to-get-utm-parameters-into-stripe": {
     "en": "/blog/the-best-way-to-get-utm-parameters-into-stripe",
@@ -528,19 +529,23 @@ export const pathnames: Record<string, Record<string, string>> = {
   },
   "/articles/abuse": {
     "en": "/legal/report-abuse",
-    "lastmod": "2025-09-14T00:00:00.000Z"
+    "lastmod": "2025-09-14T00:00:00.000Z",
+    "fr": "/legal/report-abuse"
   },
   "/articles/imprint": {
     "en": "/legal/imprint",
-    "lastmod": "2025-09-14T00:00:00.000Z"
+    "lastmod": "2025-09-14T00:00:00.000Z",
+    "fr": "/legal/imprint"
   },
   "/articles/privacy": {
     "en": "/legal/privacy-policy",
-    "lastmod": "2025-09-14T00:00:00.000Z"
+    "lastmod": "2025-09-14T00:00:00.000Z",
+    "fr": "/legal/privacy-policy"
   },
   "/articles/terms": {
     "en": "/legal/terms-of-service",
-    "lastmod": "2025-09-14T00:00:00.000Z"
+    "lastmod": "2025-09-14T00:00:00.000Z",
+    "fr": "/legal/terms-of-service"
   },
   "/landings/2octobre": {
     "en": "/2october",


### PR DESCRIPTION
## Complete A-Z rewrite

### What changed
- **All sections rewritten** from scratch after SERP + Taap.it docs research
- **Critical correction**: Taap.it has lead/sale tracking API endpoints (discovered in docs.taap.it) — but requires custom dev work (SDK, cookies, API calls). Article now accurately reflects this while showing PIMMS no-code approach is far superior for most users.
- **New section**: "The conversion tracking gap" — detailed comparison of API-only vs no-code attribution
- **Stronger PIMMS positioning**: B2B professionals and e-commerce, not just bio page users
- **Added FR version** (was EN only before)
- **Both have deep linking**: Now properly acknowledged that PIMMS also has deep linking (100+ apps) and QR codes

### Key positioning
- Taap.it = bio page builder, great for creators, free custom domains
- PIMMS = marketing attribution platform, essential for anyone who sells online
- PIMMS does everything Taap.it does for links (deep linking, QR codes) + revenue attribution, UTM management, A/B testing, server-side tracking
- €129 lifetime vs subscription pricing