### PR TITLE
fix: convert FAQ sections to ::: faq directive format

### DIFF
--- a/content/en/blog/common-utm-tracking-mistakes-how-to-fix.mdx
+++ b/content/en/blog/common-utm-tracking-mistakes-how-to-fix.mdx
@@ -197,28 +197,50 @@ Managing UTM parameters manually across dozens of campaigns is where most mistak
 - **Deep linking:** Links route mobile users directly to the right app screen, avoiding the in-app browser problem that loses conversion data.
 - **Team collaboration:** Multiple team members use the same link management workspace, reducing convention drift.
 
-## Frequently Asked Questions
+::: faq
 
 ### How do I audit my existing UTM data for mistakes?
 
 Export your GA4 acquisition report grouped by source, medium, and campaign. Sort alphabetically and look for near-duplicates: `facebook` vs `Facebook`, `email` vs `Email`, `cpc` vs `CPC`. Merge the duplicates in a spreadsheet to understand the true numbers, then fix the conventions going forward.
 
+:::
+
+::: faq
+
 ### Can I retroactively fix broken UTM data?
 
 No. Once data is recorded in Google Analytics with incorrect UTM values, it cannot be changed. You can create data filters or use BigQuery to normalize historical data in custom reports, but the raw data in GA4 is permanent. Prevention is the only reliable solution.
+
+:::
+
+::: faq
 
 ### Do UTM parameters affect SEO rankings?
 
 No. Google ignores UTM parameters for ranking purposes. However, if UTM-tagged URLs get indexed (which can happen if someone links to a UTM-tagged URL), you may see duplicate pages in search results. Add canonical tags to your pages to prevent this, or use a robots.txt rule to block UTM-tagged URL variants from indexing.
 
+:::
+
+::: faq
+
 ### How many UTM parameters is too many?
 
 There is no technical limit, but using all five parameters on every link is rarely necessary. Most campaigns need three (source, medium, campaign). Add `utm_content` when you have multiple links in the same message. Add `utm_term` only for paid search keywords or audience segments.
+
+:::
+
+::: faq
 
 ### Should every team member create their own UTM links?
 
 Ideally, no. Centralize link creation through a tool like [PIMMS](https://pimms.io) or a shared UTM builder template. The fewer people manually typing UTM values, the fewer errors you will have. If team members must create their own links, provide a template with dropdown menus for allowed values.
 
+:::
+
+::: faq
+
 ### What is the biggest UTM mistake that wastes the most budget?
 
 Tagging internal links. When internal links carry UTM parameters, they overwrite the original traffic source for every visitor who clicks them. A paid ad that cost $5,000 might show zero conversions because an internal banner link overwrote the attribution. This is both the most common and the most damaging mistake.
+
+:::

--- a/content/en/blog/link-rotation-ab-testing-landing-pages.mdx
+++ b/content/en/blog/link-rotation-ab-testing-landing-pages.mdx
@@ -421,27 +421,47 @@ Unlike basic URL shorteners that only track clicks, PIMMS tracks complete conver
 
 ---
 
-## Frequently Asked Questions
+::: faq
 
 ### What's the difference between link rotation and A/B testing?
 
 Link rotation is a URL-level traffic distribution technique that automatically sends visitors to different landing pages from a single link, while A/B testing is the broader concept of comparing two or more variants to determine which performs better. Link rotation serves as the mechanism for implementing landing page A/B tests without requiring developer implementation or complex analytics setup. Traditional A/B testing tools require JavaScript installation and weeks of setup; link rotation works immediately through smart URL technology.
 
+:::
+
+::: faq
+
 ### How much traffic do I need for link rotation to be effective?
 
 For statistically significant results at 95% confidence with a 5% margin of error, you need approximately 1,500-3,000 visitors per variant depending on your baseline conversion rate. If you convert at 10%, you need about 2,300 visitors per variant. With lower traffic, use weighted distribution (70/30 or 80/20) to gather data while minimizing risk. Even with limited traffic (100-200 visits/week), link rotation remains valuable for gradual winner identification over longer time periods.
+
+:::
+
+::: faq
 
 ### Can I change rotation settings after distributing the link?
 
 Yes — this is link rotation's core advantage over traditional A/B testing. Since rotation operates at the smart link level, you can update traffic distribution, add new variants, remove underperformers, or shift 100% traffic to winners without changing the distributed URL. This flexibility enables real-time optimization that traditional A/B testing cannot provide.
 
+:::
+
+::: faq
+
 ### How do I attribute conversions to specific landing page variants?
 
 Smart link platforms automatically append variant identifiers to destination URLs (e.g., `?variant=a` or `?variant=b`), which get captured by tracking scripts, form tools, or payment platforms. This variant parameter flows through your conversion funnel, allowing attribution of form submissions, purchases, or bookings back to the specific landing page that drove them. Platforms like PIMMS automate this entire attribution flow without requiring manual UTM configuration.
 
+:::
+
+::: faq
+
 ### Should I use 50/50 or weighted traffic distribution?
 
 Use 50/50 distribution when both variants represent acceptable experiences, you have sufficient traffic (1,000+ visits/week), and you want fastest statistical significance. Use weighted distribution (70/30 or 80/20) when testing risky changes, you have limited traffic, or you're gradually rolling out new experiences. Weighted distribution minimizes downside risk while still gathering actionable data about variant performance.
+
+:::
+
+::: faq
 
 ### How long should I run a link rotation test?
 
@@ -449,6 +469,7 @@ Run tests until you achieve statistical significance (typically 95% confidence) 
 
 ---
 
+:::
 ## Start Rotating Links to Optimize Conversions
 
 Link rotation transforms static URLs into dynamic testing instruments that continuously optimize for conversions. By distributing traffic across landing page variants, tracking conversion performance, and reallocating traffic toward winners, marketers achieve 20-30% conversion improvements without technical dependencies.

--- a/content/en/blog/multi-touch-attribution-models-complete-comparison-2026.mdx
+++ b/content/en/blog/multi-touch-attribution-models-complete-comparison-2026.mdx
@@ -397,32 +397,53 @@ For example, a SaaS founder using PIMMS discovered that 68% of their paid custom
 
 **The fix:** Choose a primary model and stick with it for at least 6-12 months. Run secondary models in parallel for comparison, but don't change your decision-making framework constantly.
 
-## Frequently Asked Questions
+::: faq
 
 ### What's the difference between multi-touch and multi-channel attribution?
 
 Multi-touch attribution assigns credit across multiple touchpoints in a single customer's journey, regardless of channel. Multi-channel attribution specifically looks at how different marketing channels (email, social, paid search) contribute to conversions. Multi-touch is the methodology; multi-channel describes the scope. Most modern attribution is both multi-touch and multi-channel.
 
+:::
+
+::: faq
+
 ### How much data do I need for multi-touch attribution?
 
 For rule-based models (linear, time decay, U-shaped), you need a minimum of 100 conversions per month to see meaningful patterns. For algorithmic models, you need 10,000+ conversions annually for the machine learning to be statistically reliable. According to a 2024 study by Marketing Evolution, 72% of companies wait until they have at least 500 monthly conversions before implementing multi-touch attribution.
+
+:::
+
+::: faq
 
 ### Can I use multi-touch attribution with a small marketing budget?
 
 Yes. Multi-touch attribution is about measurement methodology, not budget size. Even if you're only running email and organic social, multi-touch attribution helps you understand which messages and channels drive conversions. PIMMS offers multi-touch attribution starting at €0/month, making it accessible for startups and small businesses.
 
+:::
+
+::: faq
+
 ### Should I use different attribution models for different goals?
 
 Yes, this is called multi-model attribution. Use last-click for immediate ROI decisions, first-click for awareness campaign evaluation, and linear for holistic journey insights. According to Nielsen's 2024 Marketing Attribution Report, 56% of enterprise marketing teams use multiple attribution models simultaneously to answer different business questions.
+
+:::
+
+::: faq
 
 ### How do I explain multi-touch attribution to my CEO?
 
 Use this analogy: "Imagine a soccer team where only the player who scored the goal got credit. You'd have no way to value the defense, midfield, or assists. Multi-touch attribution is like giving credit to the entire team based on their contribution to wins." Then show concrete examples: "Last month, last-click attribution said our blog drove $5K in revenue. Multi-touch shows it actually influenced $47K worth of deals — we were about to cut our content budget."
 
+:::
+
+::: faq
+
 ### Does multi-touch attribution work for B2C?
 
 Yes, but the models differ from B2B. B2C typically uses time decay or U-shaped models with shorter attribution windows (7-30 days vs. 90-180 days for B2B). E-commerce brands often use algorithmic attribution due to high conversion volumes. According to Shopify's 2024 Commerce Trends Report, 68% of direct-to-consumer brands use some form of multi-touch attribution.
 
+:::
 ## Key Takeaways
 
 **Multi-touch attribution matters more than ever:** With customers using an average of 3.2 devices and 8.4 touchpoints before converting (Google 2024), single-touch models miss the complete picture.

--- a/content/en/blog/qr-code-tracking-attribution-marketing.mdx
+++ b/content/en/blog/qr-code-tracking-attribution-marketing.mdx
@@ -350,27 +350,47 @@ For workflow integration, see our guide on [cross-channel automation](/articles/
 
 ---
 
-## Frequently Asked Questions
+::: faq
 
 ### What's the difference between static and dynamic QR codes?
 
 Static QR codes encode the destination URL directly into the QR pattern itself. Once printed, the URL cannot be changed without generating a new code. Dynamic QR codes contain a short redirect URL that points to a smart link platform, which then redirects to your target URL. This allows you to update the destination, track scans, and gather analytics after printing. For marketing campaigns, dynamic QR codes are essential — they provide tracking data and flexibility that static codes cannot offer.
 
+:::
+
+::: faq
+
 ### How do I track conversions from QR code scans?
 
 To track conversions from QR scans, embed UTM parameters in the QR destination URL, install tracking scripts on landing pages, and integrate conversion events from forms (Tally, Typeform, Webflow), payment platforms (Stripe, Shopify), or booking tools (Cal.com, Calendly). Smart link platforms like PIMMS automate this process by capturing the QR scan parameters, passing them through the conversion funnel, and attributing final purchases or signups back to the original QR campaign.
+
+:::
+
+::: faq
 
 ### Can I change where a QR code points after printing it?
 
 Yes, if you use dynamic QR codes. Dynamic codes point to an intermediary short URL that redirects to your target destination. You can change this target destination at any time through your QR management platform without reprinting materials. This is essential for fixing broken links, updating expired offers, or A/B testing different landing pages from the same printed QR code.
 
+:::
+
+::: faq
+
 ### What UTM parameters should I use for QR codes?
 
 For QR codes, use this UTM structure: `utm_source` for the specific placement (magazine-name, packaging, event-name), `utm_medium=qr` or `utm_medium=qr-print` to identify the channel, `utm_campaign` for the campaign name, and `utm_content` for placement-specific details (page-number, batch-code, booth-location). This granularity lets you track performance by publication, product, event, or retail location — revealing exactly which placements justify their costs.
 
+:::
+
+::: faq
+
 ### How do I measure ROI from QR code campaigns?
 
 Calculate QR campaign ROI by dividing net revenue by campaign cost. Track total campaign expenses (design, printing, distribution), measure QR scans, count conversions from those scans, and connect conversions to actual revenue through payment integration. Formula: ROI = ((Revenue - Cost) / Cost) × 100. Smart attribution platforms automatically calculate this by connecting QR scan data to Stripe or Shopify transactions, showing per-campaign profitability in real-time dashboards.
+
+:::
+
+::: faq
 
 ### Do QR codes work for offline-to-online attribution?
 
@@ -378,6 +398,7 @@ Yes, QR codes are the most effective bridge for offline-to-online attribution. T
 
 ---
 
+:::
 ## Start Tracking QR Code Attribution Today
 
 QR codes have evolved from simple redirects to sophisticated attribution tools. By implementing trackable QR codes with UTM parameters, dynamic link technology, and conversion integration, you transform offline marketing into a measurable, optimizable revenue channel.

--- a/content/en/blog/track-marketing-roi-campaign-cost-attribution.mdx
+++ b/content/en/blog/track-marketing-roi-campaign-cost-attribution.mdx
@@ -587,27 +587,47 @@ Unlike standalone analytics tools that track revenue OR costs, PIMMS unifies bot
 
 ---
 
-## Frequently Asked Questions
+::: faq
 
 ### What's a good marketing ROI benchmark?
 
 Marketing ROI varies significantly by industry, business model, and campaign type. According to Nielsen's 2025 Marketing ROI Report, median ROI is 200-250% (earning $2-2.50 for every $1 spent). High-performing campaigns achieve 400-600% ROI. Early-stage startups investing in brand awareness may accept 100-150% ROI, while mature companies optimizing performance campaigns target 300-500%. SaaS companies should aim for LTV:CAC ratios above 3:1 with CAC payback under 12 months.
 
+:::
+
+::: faq
+
 ### How do I calculate ROI for brand awareness campaigns?
 
 Brand awareness campaigns generate long-term value that's difficult to track immediately. Use these approaches: (1) Proxy metrics like brand search volume increases, (2) Incrementality testing with control groups to isolate awareness campaign impact, (3) Extended attribution windows (90-180 days) to capture delayed conversions, (4) Survey-based brand lift studies measuring awareness and consideration changes. Assign estimated value to awareness metrics based on historical conversion rates from aware to purchased.
+
+:::
+
+::: faq
 
 ### Should I track costs by campaign or by channel?
 
 Track both. Channel-level costs show "we spend $50,000/month on Facebook Ads," while campaign-level costs reveal "Product Launch Campaign spent $8,000 with 325% ROI while Awareness Campaign spent $12,000 with 95% ROI." Channel aggregation hides winners and losers; campaign granularity enables optimization. Use UTM parameters to map channel spend to specific campaigns automatically.
 
+:::
+
+::: faq
+
 ### How do I attribute costs when customers touch multiple campaigns?
 
 Use multi-touch attribution models to distribute costs across the customer journey. Position-based attribution assigns 40% cost to first touch, 40% to last touch, and 20% to middle touches. Time-decay attribution gives more cost credit to recent touches. Linear attribution divides costs equally. Choose models based on your business: position-based for balanced view, time-decay for sales-focused teams, first-touch for awareness measurement.
 
+:::
+
+::: faq
+
 ### What's the difference between ROI and ROAS?
 
 ROI (Return on Investment) measures profit as a percentage: ROI = ((Revenue - Cost) / Cost) × 100. ROAS (Return on Ad Spend) measures revenue as a ratio: ROAS = Revenue / Cost. Example: $10,000 revenue from $2,000 spend = 400% ROI or 5:1 ROAS. ROI shows profitability percentage; ROAS shows revenue multiple. Use ROI for profitability decisions and ROAS for revenue-focused performance marketing where profit margins are consistent.
+
+:::
+
+::: faq
 
 ### How often should I review campaign cost attribution?
 
@@ -615,6 +635,7 @@ Review frequency depends on spend level and campaign duration. Daily reviews for
 
 ---
 
+:::
 ## Start Tracking True Marketing ROI Today
 
 Campaign cost attribution transforms marketing from subjective opinions into objective profit-and-loss analysis. By tracking all marketing expenses, mapping costs to campaigns via UTM parameters, connecting spend to revenue outcomes, and calculating ROI at campaign and channel levels, you eliminate wasted spend and confidently scale what works.

--- a/content/en/blog/utm-tracking-for-email-marketing-campaigns.mdx
+++ b/content/en/blog/utm-tracking-for-email-marketing-campaigns.mdx
@@ -215,28 +215,50 @@ utm_term=\{subscriber.segment\}
 
 Encode the audience segment in `utm_term` to see how different subscriber groups respond to the same email.
 
-## Frequently Asked Questions
+::: faq
 
 ### Should I use utm_source=newsletter or utm_source=mailchimp?
 
 Use the platform name (mailchimp, hubspot) as `utm_source` if you want to compare ESP performance. Use a descriptive name (newsletter, weekly-digest) if you only use one platform and care more about content type. The key is consistency — pick one convention and document it.
 
+:::
+
+::: faq
+
 ### Do UTM parameters work with AMP emails?
 
 Yes. AMP emails support standard URL parameters including UTM tags. The parameters are passed through when a subscriber clicks a link, just like in regular HTML emails. However, AMP email adoption remains limited, so ensure your fallback HTML version is also properly tagged.
+
+:::
+
+::: faq
 
 ### How many UTM parameters should I use per link?
 
 Use at least three: `utm_source`, `utm_medium`, and `utm_campaign`. Add `utm_content` when you have multiple links in the same email. Use `utm_term` for audience segmentation. More parameters give you more granular data, but do not add parameters you will never analyze.
 
+:::
+
+::: faq
+
 ### Can UTM tracking replace my ESP's built-in analytics?
 
 No. ESP analytics (open rates, click rates, unsubscribe rates) measure email engagement. UTM tracking measures what happens after the click — website behavior, conversions, and revenue. Use both together for the complete picture.
+
+:::
+
+::: faq
 
 ### How do I handle UTM tracking for emails with dozens of links?
 
 Use a smart link tool like [PIMMS](https://pimms.io) to create managed links with embedded UTM parameters. This is faster than manually tagging 20+ URLs per email and ensures consistency. Set `utm_content` to identify each link position (e.g., `intro-link`, `product-1`, `product-2`, `footer-cta`).
 
+:::
+
+::: faq
+
 ### Does Gmail clip emails with UTM-tagged links?
 
 Gmail clips emails that exceed approximately 102 KB in size. UTM parameters add bytes to each URL, but the impact is minimal — typically 100-200 bytes per link. If your email has 30+ tagged links, check the total size before sending. Using short links eliminates this concern entirely.
+
+:::

--- a/content/en/blog/utm-tracking-for-paid-ads-google-meta-linkedin.mdx
+++ b/content/en/blog/utm-tracking-for-paid-ads-google-meta-linkedin.mdx
@@ -248,28 +248,50 @@ UTM tracking enables true cross-platform ROI calculation:
 
 Tools like [PIMMS](https://pimms.io) automate steps 1-4 by connecting your ad clicks directly to Stripe or Shopify revenue, showing ROAS per campaign in a single dashboard without manual data stitching.
 
-## Frequently Asked Questions
+::: faq
 
 ### Should I use auto-tagging or manual UTMs for Google Ads?
 
 Use auto-tagging as your primary method if GA4 is your analytics platform — it provides the most detailed data with zero maintenance. Add manual UTMs only if you use additional analytics tools that cannot read `gclid`, or if you need cross-platform naming consistency.
 
+:::
+
+::: faq
+
 ### What utm_medium should I use for paid social ads?
 
 Use `paid-social` or `paidsocial` for paid social campaigns on Meta, LinkedIn, TikTok, and Twitter/X. This keeps paid social separate from organic social (`utm_medium=social`) in your GA4 channel grouping reports.
+
+:::
+
+::: faq
 
 ### How do I track which ad creative converts best?
 
 Use `utm_content` to encode the creative variant. For example: `utm_content=video-testimonial-30s` vs `utm_content=static-product-image`. In GA4, create an exploration report grouped by `utm_content` with your conversion metric as the value.
 
+:::
+
+::: faq
+
 ### Do I need UTM tracking if I use Meta's Conversions API?
 
 Yes. Meta's Conversions API tracks events within Meta's ecosystem for ad optimization and reporting. UTM parameters track the same events in your own analytics platform (GA4, Mixpanel, PIMMS). Both serve different purposes and should be used together.
+
+:::
+
+::: faq
 
 ### How do I handle UTM tracking for retargeting campaigns?
 
 Tag retargeting campaigns with a distinct `utm_campaign` value, such as `2026-q1-retargeting-cart-abandon`. This separates retargeting conversions from prospecting conversions in your analytics, giving you accurate CPA and ROAS for each campaign type.
 
+:::
+
+::: faq
+
 ### Can UTM parameters track view-through conversions?
 
 No. UTM parameters only fire when a user clicks a link. View-through conversions (where someone sees an ad but does not click) require platform-specific tracking pixels (Meta Pixel, LinkedIn Insight Tag) or a multi-touch attribution tool. UTM tracking captures click-through attribution only.
+
+:::


### PR DESCRIPTION
Convert plain markdown FAQ sections to ::: faq directive blocks in 7 articles for proper FAQPage schema extraction.

**Articles fixed (7):**
- common-utm-tracking-mistakes-how-to-fix
- link-rotation-ab-testing-landing-pages
- multi-touch-attribution-models-complete-comparison-2026
- qr-code-tracking-attribution-marketing
- track-marketing-roi-campaign-cost-attribution
- utm-tracking-for-email-marketing-campaigns
- utm-tracking-for-paid-ads-google-meta-linkedin

No content changes — only formatting.